### PR TITLE
remove vite/dynamic-import-polyfill

### DIFF
--- a/packages/storybook-builder-vite/codegen-iframe-script.js
+++ b/packages/storybook-builder-vite/codegen-iframe-script.js
@@ -45,9 +45,7 @@ module.exports.generateIframeScriptCode = async function generateIframeScriptCod
             .map((_, i) => `${name}_${i}`)
             .join(',')}]`;
 
-    const code = `
-    import 'vite/dynamic-import-polyfill';
-  
+    const code = `  
     /* ${previewEntries
         .map((entry) => `// preview entry\nimport '${entry}';`)
         .join('\n')} */


### PR DESCRIPTION
When running storybook, I saw this message in terminal
```
'vite/dynamic-import-polyfill' is no longer needed, refer to https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md#230-2021-05-10
```