### PR TITLE
Simple manual CI

### DIFF
--- a/.github/workflows/buildAndPublish.yml
+++ b/.github/workflows/buildAndPublish.yml
@@ -1,0 +1,35 @@
+name: Node CI
+
+on: [workflow_dispatch]
+
+defaults:
+  run:
+    working-directory: packages/storybook-builder-vite
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: npm / registry setup ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: https://registry.npmjs.org/
+    - name: npm install, build, and test
+      run: |
+        npm install
+        npm run build --if-present
+      env:
+        CI: true
+    - name: Publish if version is new
+      continue-on-error: true
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/buildAndPublish.yml
+++ b/.github/workflows/buildAndPublish.yml
@@ -1,4 +1,4 @@
-name: Node CI
+name: Build and Publish to NPM
 
 on: [workflow_dispatch]
 


### PR DESCRIPTION
Here is a simple version of the CI.

What it does:

1. Should push to npm if you define a secret called:  NPM_TOKEN

What it doesn't do:

1. Version.  I wasn't sure how you wanted to do it.  So for now you could just run  
`npm version` 
or 
`yarn version` 

2.  Set the npm package public.  (But you can add this by adding --access public to the npm publish command)


As this PR sits you could use it like this:

1. Decide to release
2. npm version
3. push
4. run CI
5. Set package to public when you wanted to.





