### PR TITLE
Return totalTime and bail function

### DIFF
--- a/packages/storybook-builder-vite/index.js
+++ b/packages/storybook-builder-vite/index.js
@@ -41,6 +41,21 @@ module.exports.start = async function start({
 
     router.use(await iframeMiddleware(options, server));
     router.use(server.middlewares);
+
+    function bail(e) {
+        try {
+            server.close();
+        } catch (err) {
+            console.warn('unable to close vite server');
+        }
+
+        throw e;
+    }
+
+    return {
+        bail,
+        totalTime: process.hrtime(startTime),
+    };
 };
 
 module.exports.build = async function build({ options }) {


### PR DESCRIPTION
It seems that builders are expected to return a few things when they start up, or at least that's how the webpack ones work.  A `totalTime` is used to show the time it takes the preview to start up in the box that storybook makes, and a `bail` function that as far as I can tell shuts down the server.  

Here's an example of what I see with these changes:

![image](https://user-images.githubusercontent.com/4616705/121366943-e0e52600-c907-11eb-8d6f-6cda203742e4.png)

I think it's cool to show the vite startup time, since it's so dramatically small (this was an uncached build).  :)

Bail might only be a webpack thing, I'm not sure, but I figure it can't hurt to include it.