### PR TITLE
Add github links to package.json

### DIFF
--- a/packages/storybook-builder-vite/package.json
+++ b/packages/storybook-builder-vite/package.json
@@ -6,6 +6,12 @@
     "scripts": {},
     "author": "Eirik Sletteberg",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/eirslett/storybook-builder-vite.git",
+        "directory": "package/storybook-builder-vite"
+    },
+    "homepage": "https://github.com/eirslett/storybook-builder-vite/#readme",
     "dependencies": {
         "@mdx-js/mdx": "^1.6.22",
         "@storybook/addon-docs": "^6.3.0-alpha.14",


### PR DESCRIPTION
The npmjs.com [site for this project](https://www.npmjs.com/package/storybook-builder-vite) looks a little barren.  Adding some links to the package.json should fix that.