### PR TITLE
Do not depend on framework plugins (mostly)

### DIFF
--- a/packages/storybook-builder-vite/package.json
+++ b/packages/storybook-builder-vite/package.json
@@ -14,13 +14,15 @@
     "homepage": "https://github.com/eirslett/storybook-builder-vite/#readme",
     "dependencies": {
         "@mdx-js/mdx": "^1.6.22",
-        "@storybook/addon-svelte-csf": "^1.1.0",
         "@storybook/csf-tools": "^6.3.0-rc.4",
-        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.7",
         "@vitejs/plugin-react-refresh": "^1.3.2",
-        "@vitejs/plugin-vue": "^1.2.1",
         "glob-promise": "^4.1.0",
         "vite-plugin-mdx": "^3.5.1"
+    },
+    "devDependencies": {
+        "@storybook/addon-svelte-csf": "^1.1.0",
+        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.7",
+        "@vitejs/plugin-vue": "^1.2.1"
     },
     "peerDependencies": {
         "vite": "^2.3.2"

--- a/packages/storybook-builder-vite/vite-config.js
+++ b/packages/storybook-builder-vite/vite-config.js
@@ -13,11 +13,36 @@ module.exports.pluginConfig = function pluginConfig(options, type) {
         }),
     ];
     if (framework === 'vue' || framework === 'vue3') {
-        plugins.push(require('@vitejs/plugin-vue')());
+        try {
+            const vuePlugin = require('@vitejs/plugin-vue')
+            plugins.push(vuePlugin());
+        } catch (err) {
+            if (err.code !== 'MODULE_NOT_FOUND') {
+                throw new Error('storybook-builder-vite requires @vitejs/plugin-vue to be installed when using @storybook/vue or @storybook/vue3.  Please install it and start storybook again.');
+            }
+            throw err;
+        }
     }
     if (framework === 'svelte') {
-        plugins.push(require('@sveltejs/vite-plugin-svelte').svelte());
-        plugins.push(require('./svelte/csf-plugin'));
+        try {
+            const sveltePlugin = require('@sveltejs/vite-plugin-svelte').svelte
+            plugins.push(sveltePlugin());
+        } catch (err) {
+            if (err.code !== 'MODULE_NOT_FOUND') {
+                throw new Error('storybook-builder-vite requires @vitejs/plugin-vue to be installed when using @storybook/svelte.  Please install it and start storybook again.');
+            }
+            throw err;
+        }
+
+        try {
+            const csfPlugin = require('./svelte/csf-plugin');
+            plugins.push(csfPlugin);
+        } catch (err) {
+            if (err.code !== 'MODULE_NOT_FOUND') {
+                throw new Error('storybook-builder-vite requires @storybook/addon-svelte-csf to be installed when using @storybook/svelte.  Please install it and start storybook again.');
+            }
+            throw err;
+        }
     }
 
     if (type === 'development') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,18 +1913,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/pluginutils@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@rollup/pluginutils@npm:4.1.0"
-  dependencies:
-    estree-walker: ^2.0.1
-    picomatch: ^2.2.2
-  peerDependencies:
-    rollup: ^1.20.0||^2.0.0
-  checksum: 566b8d2bcc0d52877f8c9f364026be40fa921c8d5860b5f2a5f476658dfebf462536632f079aa3f52fafe64d8aea6741c20bb198e67b33eaba8f9fe69b38ae3f
-  languageName: node
-  linkType: hard
-
 "@storybook/addon-a11y@npm:^6.3.0-rc.4":
   version: 6.3.0-rc.4
   resolution: "@storybook/addon-a11y@npm:6.3.0-rc.4"
@@ -2224,7 +2212,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-svelte-csf@npm:^1.0.0, @storybook/addon-svelte-csf@npm:^1.1.0":
+"@storybook/addon-svelte-csf@npm:^1.0.0":
   version: 1.1.0
   resolution: "@storybook/addon-svelte-csf@npm:1.1.0"
   dependencies:
@@ -3194,22 +3182,6 @@ __metadata:
     start-storybook: bin/index.js
     storybook-server: bin/index.js
   checksum: 72e3549ac133a49c2c1da90fdca22df75e74026ec9a693a05469129ef5625753dede45ffc1176aeb3e7789ec181f59a15feff75179a5d6c515db8968a26f8cc6
-  languageName: node
-  linkType: hard
-
-"@sveltejs/vite-plugin-svelte@npm:^1.0.0-next.7":
-  version: 1.0.0-next.11
-  resolution: "@sveltejs/vite-plugin-svelte@npm:1.0.0-next.11"
-  dependencies:
-    "@rollup/pluginutils": ^4.1.0
-    chalk: ^4.1.1
-    debug: ^4.3.2
-    require-relative: ^0.8.7
-    svelte-hmr: ^0.14.4
-  peerDependencies:
-    svelte: ^3.38.2
-    vite: ^2.3.7
-  checksum: 51814994fa7125956fad4df458db1386965b6eac43e5183199f4fbbb3c918d8bed0c5d8c7a0fb2660a230586a7fef1dae488cffbdfed460ca43b0e40085f36b3
   languageName: node
   linkType: hard
 
@@ -5112,7 +5084,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
   version: 4.1.1
   resolution: "chalk@npm:4.1.1"
   dependencies:
@@ -5869,7 +5841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2":
+"debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1":
   version: 4.3.2
   resolution: "debug@npm:4.3.2"
   dependencies:
@@ -10733,7 +10705,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.2, picomatch@npm:^2.2.3":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3":
   version: 2.3.0
   resolution: "picomatch@npm:2.3.0"
   checksum: 80113a0fb70cfa62730d5aa3fd3d45b76bf3985f8494080ab2de1cc1fa3ba96d77990c7553a81401e16c51c0eb19c27cf5bc94f2196155090f26c8a167968001
@@ -12107,13 +12079,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"require-relative@npm:^0.8.7":
-  version: 0.8.7
-  resolution: "require-relative@npm:0.8.7"
-  checksum: d07306c1ebfae4aaebeba64ff06ac453483fef1a18ee7bd2ef0460a94020f32f5135291ee0ae579ae7dde1d2d4bdc7bf3731fccb03fda937e07485245fbaadf3
-  languageName: node
-  linkType: hard
-
 "resolve-from@npm:^4.0.0":
   version: 4.0.0
   resolution: "resolve-from@npm:4.0.0"
@@ -12912,11 +12877,8 @@ fsevents@^1.2.7:
   resolution: "storybook-builder-vite@workspace:packages/storybook-builder-vite"
   dependencies:
     "@mdx-js/mdx": ^1.6.22
-    "@storybook/addon-svelte-csf": ^1.1.0
     "@storybook/csf-tools": ^6.3.0-rc.4
-    "@sveltejs/vite-plugin-svelte": ^1.0.0-next.7
     "@vitejs/plugin-react-refresh": ^1.3.2
-    "@vitejs/plugin-vue": ^1.2.1
     glob-promise: ^4.1.0
     vite-plugin-mdx: ^3.5.1
   peerDependencies:
@@ -13194,15 +13156,6 @@ fsevents@^1.2.7:
   dependencies:
     has-flag: ^4.0.0
   checksum: 8e57067c39216f3c2ffce7cc14ca934d54746192571203aa9c9922d97d2d55cc1bdaa9e41a11f91e620670b5a74ebdec6b548a885d8cc2dea7cab59e21416029
-  languageName: node
-  linkType: hard
-
-"svelte-hmr@npm:^0.14.4":
-  version: 0.14.4
-  resolution: "svelte-hmr@npm:0.14.4"
-  peerDependencies:
-    svelte: ">=3.19.0"
-  checksum: f0d4c21e5b7a653ccad24cf197ead9e00425050b24aee73ee4d510d0d09f0bbf04324c4c4b729a394c1524ba895f06120b5abe9a12e7df99eab6c36832174751
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #41 

This removes the direct dependency on a few plugins, most notably @storybook/addon-svelte-csf, which causes @storybook/svelte to also be installed, which can cause storybook to run in svelte mode when it shouldn't.

This takes the approach of moving vue and svelte addons/plugins to devDependencies and throwing a friendly error message if they are attempted to be required but are not found.

I did not give react the same treatment, because I am planning to publish a forked version of plugin-react-refresh which should allow us to restart the builder when stories change, so that changes at least appear, even if they're not HMR'ed.