### PR TITLE
Added docgen info to Vite output for SFC components

### DIFF
--- a/packages/example-vue/.storybook/preview.js
+++ b/packages/example-vue/.storybook/preview.js
@@ -1,6 +1,7 @@
 export const parameters = {
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
+        expanded: true,
         matchers: {
             color: /(background|color)$/i,
             date: /Date$/,

--- a/packages/example-vue/stories/Button.stories.js
+++ b/packages/example-vue/stories/Button.stories.js
@@ -3,13 +3,13 @@ import MyButton from './Button.vue';
 export default {
     title: 'Example/Button',
     component: MyButton,
-    argTypes: {
-        backgroundColor: { control: 'color' },
-        size: {
-            control: { type: 'select', options: ['small', 'medium', 'large'] },
-        },
-        onClick: {},
-    },
+    // argTypes: {
+    //     backgroundColor: { control: 'color' },
+    //     size: {
+    //         control: { type: 'select', options: ['small', 'medium', 'large'] },
+    //     },
+    //     onClick: {},
+    // },
 };
 
 const Template = (args) => ({

--- a/packages/example-vue/stories/Button.stories.js
+++ b/packages/example-vue/stories/Button.stories.js
@@ -3,13 +3,13 @@ import MyButton from './Button.vue';
 export default {
     title: 'Example/Button',
     component: MyButton,
-    // argTypes: {
-    //     backgroundColor: { control: 'color' },
-    //     size: {
-    //         control: { type: 'select', options: ['small', 'medium', 'large'] },
-    //     },
-    //     onClick: {},
-    // },
+    argTypes: {
+        backgroundColor: { control: 'color' },
+        size: {
+            control: { type: 'select', options: ['small', 'medium', 'large'] },
+        },
+        onClick: {},
+    },
 };
 
 const Template = (args) => ({

--- a/packages/example-vue/stories/Button.vue
+++ b/packages/example-vue/stories/Button.vue
@@ -12,23 +12,40 @@ export default {
     name: 'my-button',
 
     props: {
+
+        /**
+         * The label of the button
+         */
         label: {
             type: String,
             required: true,
         },
+
+        /**
+         * Whether the button is primary
+         */
         primary: {
             type: Boolean,
             default: false,
         },
+
+        /**
+         * The size of the button
+         */
         size: {
             type: String,
             validator: function (value) {
                 return ['small', 'medium', 'large'].indexOf(value) !== -1;
             },
         },
+
+        /**
+         * The background colour of the button
+         */
         backgroundColor: {
             type: String,
         },
+        
     },
 
     emits: ['click'],

--- a/packages/storybook-builder-vite/package.json
+++ b/packages/storybook-builder-vite/package.json
@@ -24,5 +24,8 @@
     },
     "peerDependencies": {
         "vite": "^2.3.2"
+    },
+    "devDependencies": {
+        "vue-docgen-api": "^4.40.0"
     }
 }

--- a/packages/storybook-builder-vite/plugins/vue-docgen.js
+++ b/packages/storybook-builder-vite/plugins/vue-docgen.js
@@ -1,0 +1,18 @@
+const {
+    parse
+} = require('vue-docgen-api');
+
+module.exports = function() {
+    return {
+        name: 'vue-docgen',
+
+        async transform(src, id) {
+            if (/\.(vue)$/.test(id)) {
+                const metaData = await parse(id);
+                const metaSource = JSON.stringify(metaData);
+
+                return `${src};_sfc_main.__docgenInfo = ${metaSource}`;
+            }
+        }
+    };
+}

--- a/packages/storybook-builder-vite/vite-config.js
+++ b/packages/storybook-builder-vite/vite-config.js
@@ -14,6 +14,7 @@ module.exports.pluginConfig = function pluginConfig(options, type) {
     ];
     if (framework === 'vue' || framework === 'vue3') {
         plugins.push(require('@vitejs/plugin-vue')());
+        plugins.push(require('./plugins/vue-docgen')());
     }
     if (framework === 'svelte') {
         plugins.push(require('@sveltejs/vite-plugin-svelte').svelte());

--- a/packages/storybook-builder-vite/vite-server.js
+++ b/packages/storybook-builder-vite/vite-server.js
@@ -14,6 +14,7 @@ module.exports.createViteServer = async function createViteServer(
         configFile: false,
         root,
         server: {
+            force: true,
             middlewareMode: true,
             hmr: {
                 port,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12919,6 +12919,7 @@ fsevents@^1.2.7:
     "@vitejs/plugin-vue": ^1.2.1
     glob-promise: ^4.1.0
     vite-plugin-mdx: ^3.5.1
+    vue-docgen-api: ^4.40.0
   peerDependencies:
     vite: ^2.3.2
   languageName: unknown
@@ -14133,7 +14134,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"vue-docgen-api@npm:^4.38.0":
+"vue-docgen-api@npm:^4.38.0, vue-docgen-api@npm:^4.40.0":
   version: 4.40.0
   resolution: "vue-docgen-api@npm:4.40.0"
   dependencies:


### PR DESCRIPTION
Fixes #46 

Added docgen info to Vite (via a custom plugin) output to automatically generate controls and docs for SFC components

**Note**: _This is a really basic implementation and will likely require further refinement._