### PR TITLE
Ensure examples build in CI

### DIFF
--- a/.github/workflows/buildExamples.yml
+++ b/.github/workflows/buildExamples.yml
@@ -33,7 +33,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
 
       - name: Build examples
         run: yarn workspaces foreach -p run build-storybook

--- a/packages/example-svelte/package.json
+++ b/packages/example-svelte/package.json
@@ -17,8 +17,9 @@
         "@storybook/addon-actions": "^6.3.0-rc.4",
         "@storybook/addon-essentials": "^6.3.0-rc.4",
         "@storybook/addon-links": "^6.3.0-rc.4",
-        "@storybook/addon-svelte-csf": "^1.0.0",
+        "@storybook/addon-svelte-csf": "^1.1.0",
         "@storybook/svelte": "^6.3.0-rc.4",
+        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.7",
         "storybook-builder-vite": "0.0.9",
         "vite": "^2.3.2"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,6 +1913,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/pluginutils@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@rollup/pluginutils@npm:4.1.0"
+  dependencies:
+    estree-walker: ^2.0.1
+    picomatch: ^2.2.2
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0
+  checksum: 566b8d2bcc0d52877f8c9f364026be40fa921c8d5860b5f2a5f476658dfebf462536632f079aa3f52fafe64d8aea6741c20bb198e67b33eaba8f9fe69b38ae3f
+  languageName: node
+  linkType: hard
+
 "@storybook/addon-a11y@npm:^6.3.0-rc.4":
   version: 6.3.0-rc.4
   resolution: "@storybook/addon-a11y@npm:6.3.0-rc.4"
@@ -2212,7 +2224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-svelte-csf@npm:^1.0.0":
+"@storybook/addon-svelte-csf@npm:^1.1.0":
   version: 1.1.0
   resolution: "@storybook/addon-svelte-csf@npm:1.1.0"
   dependencies:
@@ -3182,6 +3194,22 @@ __metadata:
     start-storybook: bin/index.js
     storybook-server: bin/index.js
   checksum: 72e3549ac133a49c2c1da90fdca22df75e74026ec9a693a05469129ef5625753dede45ffc1176aeb3e7789ec181f59a15feff75179a5d6c515db8968a26f8cc6
+  languageName: node
+  linkType: hard
+
+"@sveltejs/vite-plugin-svelte@npm:^1.0.0-next.7":
+  version: 1.0.0-next.11
+  resolution: "@sveltejs/vite-plugin-svelte@npm:1.0.0-next.11"
+  dependencies:
+    "@rollup/pluginutils": ^4.1.0
+    chalk: ^4.1.1
+    debug: ^4.3.2
+    require-relative: ^0.8.7
+    svelte-hmr: ^0.14.4
+  peerDependencies:
+    svelte: ^3.38.2
+    vite: ^2.3.7
+  checksum: 51814994fa7125956fad4df458db1386965b6eac43e5183199f4fbbb3c918d8bed0c5d8c7a0fb2660a230586a7fef1dae488cffbdfed460ca43b0e40085f36b3
   languageName: node
   linkType: hard
 
@@ -5084,7 +5112,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1":
   version: 4.1.1
   resolution: "chalk@npm:4.1.1"
   dependencies:
@@ -5841,7 +5869,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1":
+"debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2":
   version: 4.3.2
   resolution: "debug@npm:4.3.2"
   dependencies:
@@ -6754,8 +6782,9 @@ __metadata:
     "@storybook/addon-actions": ^6.3.0-rc.4
     "@storybook/addon-essentials": ^6.3.0-rc.4
     "@storybook/addon-links": ^6.3.0-rc.4
-    "@storybook/addon-svelte-csf": ^1.0.0
+    "@storybook/addon-svelte-csf": ^1.1.0
     "@storybook/svelte": ^6.3.0-rc.4
+    "@sveltejs/vite-plugin-svelte": ^1.0.0-next.7
     storybook-builder-vite: 0.0.9
     svelte: ^3.38.2
     vite: ^2.3.2
@@ -10705,7 +10734,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.2, picomatch@npm:^2.2.3":
   version: 2.3.0
   resolution: "picomatch@npm:2.3.0"
   checksum: 80113a0fb70cfa62730d5aa3fd3d45b76bf3985f8494080ab2de1cc1fa3ba96d77990c7553a81401e16c51c0eb19c27cf5bc94f2196155090f26c8a167968001
@@ -12079,6 +12108,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"require-relative@npm:^0.8.7":
+  version: 0.8.7
+  resolution: "require-relative@npm:0.8.7"
+  checksum: d07306c1ebfae4aaebeba64ff06ac453483fef1a18ee7bd2ef0460a94020f32f5135291ee0ae579ae7dde1d2d4bdc7bf3731fccb03fda937e07485245fbaadf3
+  languageName: node
+  linkType: hard
+
 "resolve-from@npm:^4.0.0":
   version: 4.0.0
   resolution: "resolve-from@npm:4.0.0"
@@ -12877,8 +12913,11 @@ fsevents@^1.2.7:
   resolution: "storybook-builder-vite@workspace:packages/storybook-builder-vite"
   dependencies:
     "@mdx-js/mdx": ^1.6.22
+    "@storybook/addon-svelte-csf": ^1.1.0
     "@storybook/csf-tools": ^6.3.0-rc.4
+    "@sveltejs/vite-plugin-svelte": ^1.0.0-next.7
     "@vitejs/plugin-react-refresh": ^1.3.2
+    "@vitejs/plugin-vue": ^1.2.1
     glob-promise: ^4.1.0
     vite-plugin-mdx: ^3.5.1
   peerDependencies:
@@ -13156,6 +13195,15 @@ fsevents@^1.2.7:
   dependencies:
     has-flag: ^4.0.0
   checksum: 8e57067c39216f3c2ffce7cc14ca934d54746192571203aa9c9922d97d2d55cc1bdaa9e41a11f91e620670b5a74ebdec6b548a885d8cc2dea7cab59e21416029
+  languageName: node
+  linkType: hard
+
+"svelte-hmr@npm:^0.14.4":
+  version: 0.14.4
+  resolution: "svelte-hmr@npm:0.14.4"
+  peerDependencies:
+    svelte: ">=3.19.0"
+  checksum: f0d4c21e5b7a653ccad24cf197ead9e00425050b24aee73ee4d510d0d09f0bbf04324c4c4b729a394c1524ba895f06120b5abe9a12e7df99eab6c36832174751
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The main problem this addresses is that we need to ensure that `yarn install` is run no matter what, even if the cache is restored.  This is because yarn relies on having an `install-state.gz` file that is gitignored and created during installations.  We were skipping the installation entirely before if there was a cache, which is the reason that https://github.com/eirslett/storybook-builder-vite/pull/45 is failing in CI.  

This also adds a missing dependency, `@sveltejs/vite-plugin-svelte` to the svelte example.  It would be yarn installed along with the rest of the workspace, but for folks using npm or using the example as a guide, it's important to have it there.