### PR TITLE
Fix React HMR in story files

### DIFF
--- a/packages/storybook-builder-vite/package.json
+++ b/packages/storybook-builder-vite/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@mdx-js/mdx": "^1.6.22",
         "@storybook/csf-tools": "^6.3.0-rc.4",
-        "@vitejs/plugin-react-refresh": "^1.3.2",
+        "@vitejs/plugin-react-refresh": "^1.3.4",
         "glob-promise": "^4.1.0",
         "vite-plugin-mdx": "^3.5.1"
     },

--- a/packages/storybook-builder-vite/vite-config.js
+++ b/packages/storybook-builder-vite/vite-config.js
@@ -47,7 +47,10 @@ module.exports.pluginConfig = function pluginConfig(options, type) {
 
     if (type === 'development') {
         if (framework === 'react') {
-            plugins.push(require('@vitejs/plugin-react-refresh')());
+            plugins.push(require('@vitejs/plugin-react-refresh')({
+                // Do not treat story files as HMR boundaries, storybook itself needs to handle them.
+                exclude: [/\.stories\.(t|j)sx?$/, /node_modules/],
+            }));
         }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,7 +61,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.14.5, @babel/core@npm:^7.1.0, @babel/core@npm:^7.1.6, @babel/core@npm:^7.12.10, @babel/core@npm:^7.12.13, @babel/core@npm:^7.7.5":
+"@babel/core@npm:7.14.5, @babel/core@npm:^7.1.0, @babel/core@npm:^7.1.6, @babel/core@npm:^7.12.10, @babel/core@npm:^7.7.5":
   version: 7.14.5
   resolution: "@babel/core@npm:7.14.5"
   dependencies:
@@ -81,6 +81,29 @@ __metadata:
     semver: ^6.3.0
     source-map: ^0.5.0
   checksum: 71c358c7a21b9bc8b6e93d704e1f5fe716f64c5111b2b8f42286a0423a554ed303b5c575f9973c9522976caaa2f6c87d3a4c077538cc8396c6d41ebcf0f3f231
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:7.14.6, @babel/core@npm:^7.14.6":
+  version: 7.14.6
+  resolution: "@babel/core@npm:7.14.6"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/generator": ^7.14.5
+    "@babel/helper-compilation-targets": ^7.14.5
+    "@babel/helper-module-transforms": ^7.14.5
+    "@babel/helpers": ^7.14.6
+    "@babel/parser": ^7.14.6
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.14.5
+    "@babel/types": ^7.14.5
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.1.2
+    semver: ^6.3.0
+    source-map: ^0.5.0
+  checksum: 239c4892d54f1d6e3a9a3972a7579138da6ff5308b9c08e4c80c9cd09282b6a921f58338851675fdb80b1cf9dd14f4176674917b97aa430bf1d50c0052bbb13a
   languageName: node
   linkType: hard
 
@@ -374,6 +397,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.14.6":
+  version: 7.14.6
+  resolution: "@babel/helpers@npm:7.14.6"
+  dependencies:
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: c5c3bd0f9618cdb8895d89171fe0b89c0b119bf8c9f96aff869d95b9208628172a882a132f8f76a218e0e68d8c3316f65b60af9b3a3a778d9b9adce004ca52c7
+  languageName: node
+  linkType: hard
+
 "@babel/highlight@npm:^7.10.4, @babel/highlight@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/highlight@npm:7.14.5"
@@ -391,6 +425,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 55c14793888cb7d54275811e7f13136875df1ee4fc368f3f10cff46ebdf95b6a072e706a0486be0ac5686a597cbfb82f33b5f66aa6ba80ff50b73bca945035c6
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.14.6":
+  version: 7.14.7
+  resolution: "@babel/parser@npm:7.14.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 8c7c7fd9735d9de2a0531fe54338d76972aeb9a414902f5edfc317c421a2da6a8772d04dce5444c89065ae2719c48433153f9cbaa14754b1bf8d6154915095ff
   languageName: node
   linkType: hard
 
@@ -1162,7 +1205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-jsx-self@npm:^7.12.13":
+"@babel/plugin-transform-react-jsx-self@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/plugin-transform-react-jsx-self@npm:7.14.5"
   dependencies:
@@ -1173,7 +1216,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-jsx-source@npm:^7.12.13":
+"@babel/plugin-transform-react-jsx-source@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/plugin-transform-react-jsx-source@npm:7.14.5"
   dependencies:
@@ -3552,15 +3595,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react-refresh@npm:^1.3.2":
-  version: 1.3.3
-  resolution: "@vitejs/plugin-react-refresh@npm:1.3.3"
+"@vitejs/plugin-react-refresh@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "@vitejs/plugin-react-refresh@npm:1.3.4"
   dependencies:
-    "@babel/core": ^7.12.13
-    "@babel/plugin-transform-react-jsx-self": ^7.12.13
-    "@babel/plugin-transform-react-jsx-source": ^7.12.13
+    "@babel/core": ^7.14.6
+    "@babel/plugin-transform-react-jsx-self": ^7.14.5
+    "@babel/plugin-transform-react-jsx-source": ^7.14.5
+    "@rollup/pluginutils": ^4.1.0
     react-refresh: ^0.9.0
-  checksum: f8c579546c24e7334abb63bd6576508e755f7087fd21df19679784824ac3154515e2c6a900eb9e599051ec0d4f1f1d2c02afcabf6d8fea10c58a2d8451a77467
+  checksum: 86823a114d0563376dadb75d23da581b90c23a92bbce11bd1c97d0ea4764d52f6cd43e6d7a58a6116a0558bc32492499dac974c16109cee16f50c4af0a3c61cc
   languageName: node
   linkType: hard
 
@@ -12916,7 +12960,7 @@ fsevents@^1.2.7:
     "@storybook/addon-svelte-csf": ^1.1.0
     "@storybook/csf-tools": ^6.3.0-rc.4
     "@sveltejs/vite-plugin-svelte": ^1.0.0-next.7
-    "@vitejs/plugin-react-refresh": ^1.3.2
+    "@vitejs/plugin-react-refresh": ^1.3.4
     "@vitejs/plugin-vue": ^1.2.1
     glob-promise: ^4.1.0
     vite-plugin-mdx: ^3.5.1


### PR DESCRIPTION
Fixes #3.

This "fixes" HMR in react story files by using the new `exclude` [option](https://github.com/vitejs/vite/pull/3916) in `@vitejs/plugin-react-refresh` to avoid treating story files as HMR boundaries, instead letting changes bubble up into the core storybook client so that it can update the manager when stories are added / deleted / changed.  When storybook detects that a story file has changed, it will trigger a reload of the preview iframe.  So, it's not exactly full seamless HMR, but it addresses the main problem of story previews not changing upon save.

To test, run `yarn install`, then `cd packages/example-react` and `yarn storybook`.  Open the button story in the browser, then make changes to the button story file (add a story, remove a story, change a story, etc).  You should see the changes reflected in the browser without requiring a manual page refresh.