### PR TITLE
Sort stories by their export order

### DIFF
--- a/packages/storybook-builder-vite/inject-export-order-plugin.js
+++ b/packages/storybook-builder-vite/inject-export-order-plugin.js
@@ -20,7 +20,7 @@ module.exports.injectExportOrderPlugin = function injectExportOrderPlugin(option
       const [, exports] = parse(code);
       if (exports.includes('__namedExportsOrder')) {
         // user has defined named exports already
-        return null;
+        return;
       }
 
       const orderedExports = exports.filter(e => e !== 'default');

--- a/packages/storybook-builder-vite/inject-export-order-plugin.js
+++ b/packages/storybook-builder-vite/inject-export-order-plugin.js
@@ -1,8 +1,8 @@
 const { parse } = require('es-module-lexer');
 
-module.exports.namedExportOrderPlugin = function namedExportOrderPlugin(options) {
+module.exports.injectExportOrderPlugin = function injectExportOrderPlugin(options) {
   return {
-    name: 'storybook-vite-named-export-order-plugin',
+    name: 'storybook-vite-inject-export-order-plugin',
     // This should only run after the typescript has been transpiled
     enforce: 'post',
     async transform(code, id) {

--- a/packages/storybook-builder-vite/inject-export-order-plugin.js
+++ b/packages/storybook-builder-vite/inject-export-order-plugin.js
@@ -1,32 +1,22 @@
 const { parse } = require('es-module-lexer');
 
-module.exports.injectExportOrderPlugin = function injectExportOrderPlugin(options) {
-  return {
+module.exports.injectExportOrderPlugin = {
     name: 'storybook-vite-inject-export-order-plugin',
     // This should only run after the typescript has been transpiled
     enforce: 'post',
     async transform(code, id) {
-      /**
-       * This doesn't feel right, we already get a list of stories in generateIframeScriptCode
-       * based on presets.apply('stories'). What's the best way for us to reuse those stories?
-       * Should we introduce a viteBuilderContext?
-       * 
-       * await options.presets.apply('stories')
-       */
-      if (!/\.stories\.(t|j)sx?$/.test(id)) {
-        return;
-      }
+        if (!/\.stories\.(t|j)sx?$/.test(id)) {
+            return;
+        }
+        const [, exports] = await parse(code);
 
-      const [, exports] = parse(code);
-      if (exports.includes('__namedExportsOrder')) {
-        // user has defined named exports already
-        return;
-      }
+        if (exports.includes('__namedExportsOrder')) {
+            // user has defined named exports already
+            return;
+        }
 
-      const orderedExports = exports.filter(e => e !== 'default');
-      const exportsArray = `['${orderedExports.join("', '")}']`;
+        const orderedExports = exports.filter(e => e !== 'default');
 
-      return `${code};\nexport const __namedExportsOrder = ${exportsArray};`;
-    }
-  }
-}
+        return `${code};\nexport const __namedExportsOrder = ${JSON.stringify(orderedExports)};`;
+    },
+};

--- a/packages/storybook-builder-vite/named-export-order-plugin.js
+++ b/packages/storybook-builder-vite/named-export-order-plugin.js
@@ -1,0 +1,32 @@
+const { parse } = require('es-module-lexer');
+
+module.exports.namedExportOrderPlugin = function namedExportOrderPlugin(options) {
+  return {
+    name: 'storybook-vite-named-export-order-plugin',
+    // This should only run after the typescript has been transpiled
+    enforce: 'post',
+    async transform(code, id) {
+      /**
+       * This doesn't feel right, we already get a list of stories in generateIframeScriptCode
+       * based on presets.apply('stories'). What's the best way for us to reuse those stories?
+       * Should we introduce a viteBuilderContext?
+       * 
+       * await options.presets.apply('stories')
+       */
+      if (!/\.stories\.(t|j)sx?$/.test(id)) {
+        return;
+      }
+
+      const [, exports] = parse(code);
+      if (exports.includes('__namedExportsOrder')) {
+        // user has defined named exports already
+        return null;
+      }
+
+      const orderedExports = exports.filter(e => e !== 'default');
+      const exportsArray = `['${orderedExports.join("', '")}']`;
+
+      return `${code};\nexport const __namedExportsOrder = ${exportsArray};`;
+    }
+  }
+}

--- a/packages/storybook-builder-vite/package.json
+++ b/packages/storybook-builder-vite/package.json
@@ -16,6 +16,7 @@
         "@mdx-js/mdx": "^1.6.22",
         "@storybook/csf-tools": "^6.3.0-rc.4",
         "@vitejs/plugin-react-refresh": "^1.3.4",
+        "es-module-lexer": "^0.6.0",
         "glob-promise": "^4.1.0",
         "vite-plugin-mdx": "^3.5.1"
     },

--- a/packages/storybook-builder-vite/svelte/csf-plugin.js
+++ b/packages/storybook-builder-vite/svelte/csf-plugin.js
@@ -33,6 +33,11 @@ module.exports = {
                 '// export default '
             );
 
+            const namedExportsOrder = Object.entries(stories)
+              .filter(([, def]) => !def.template)
+              .map(([id]) => id)
+              .join("', '");
+
             const output = [
                 codeWithoutDefaultExport,
                 `import parser from '${parser}';`,
@@ -40,6 +45,7 @@ module.exports = {
                     all
                 )});`,
                 'export default __storiesMetaData.meta;',
+                `export const __namedExportsOrder = ['${namedExportsOrder}'];`,
                 storyDef,
             ].join('\n');
             return {

--- a/packages/storybook-builder-vite/svelte/csf-plugin.js
+++ b/packages/storybook-builder-vite/svelte/csf-plugin.js
@@ -35,8 +35,7 @@ module.exports = {
 
             const namedExportsOrder = Object.entries(stories)
               .filter(([, def]) => !def.template)
-              .map(([id]) => id)
-              .join("', '");
+              .map(([id]) => id);
 
             const output = [
                 codeWithoutDefaultExport,
@@ -45,7 +44,7 @@ module.exports = {
                     all
                 )});`,
                 'export default __storiesMetaData.meta;',
-                `export const __namedExportsOrder = ['${namedExportsOrder}'];`,
+                `export const __namedExportsOrder = ${JSON.stringify(namedExportsOrder)};`,
                 storyDef,
             ].join('\n');
             return {

--- a/packages/storybook-builder-vite/vite-config.js
+++ b/packages/storybook-builder-vite/vite-config.js
@@ -14,7 +14,7 @@ module.exports.pluginConfig = function pluginConfig(options, type) {
         mdx({
             compilers: [storybookCompilerPlugin()],
         }),
-        injectExportOrderPlugin(options),
+        injectExportOrderPlugin,
     ];
     if (framework === 'vue' || framework === 'vue3') {
         try {

--- a/packages/storybook-builder-vite/vite-config.js
+++ b/packages/storybook-builder-vite/vite-config.js
@@ -4,6 +4,7 @@ const {
 } = require('@storybook/csf-tools/mdx');
 const { mockCoreJs } = require('./mock-core-js');
 const { codeGeneratorPlugin } = require('./code-generator-plugin');
+const { namedExportOrderPlugin } = require('./named-export-order-plugin');
 
 module.exports.pluginConfig = function pluginConfig(options, type) {
     const { framework } = options;
@@ -13,6 +14,7 @@ module.exports.pluginConfig = function pluginConfig(options, type) {
         mdx({
             compilers: [storybookCompilerPlugin()],
         }),
+        namedExportOrderPlugin(options),
     ];
     if (framework === 'vue' || framework === 'vue3') {
         try {

--- a/packages/storybook-builder-vite/vite-config.js
+++ b/packages/storybook-builder-vite/vite-config.js
@@ -4,7 +4,7 @@ const {
 } = require('@storybook/csf-tools/mdx');
 const { mockCoreJs } = require('./mock-core-js');
 const { codeGeneratorPlugin } = require('./code-generator-plugin');
-const { namedExportOrderPlugin } = require('./named-export-order-plugin');
+const { injectExportOrderPlugin } = require('./inject-export-order-plugin');
 
 module.exports.pluginConfig = function pluginConfig(options, type) {
     const { framework } = options;
@@ -14,7 +14,7 @@ module.exports.pluginConfig = function pluginConfig(options, type) {
         mdx({
             compilers: [storybookCompilerPlugin()],
         }),
-        namedExportOrderPlugin(options),
+        injectExportOrderPlugin(options),
     ];
     if (framework === 'vue' || framework === 'vue3') {
         try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6518,6 +6518,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "es-module-lexer@npm:0.6.0"
+  checksum: 6c7c64adab628ee53a9d90d65db13e574e1132db808d43d9a9f912944c97d36dc05d5bafed79245c8e9880cf2bcf0fef54663364fd08c8d59053717a4a69db7f
+  languageName: node
+  linkType: hard
+
 "es-to-primitive@npm:^1.2.1":
   version: 1.2.1
   resolution: "es-to-primitive@npm:1.2.1"
@@ -12962,6 +12969,7 @@ fsevents@^1.2.7:
     "@sveltejs/vite-plugin-svelte": ^1.0.0-next.7
     "@vitejs/plugin-react-refresh": ^1.3.4
     "@vitejs/plugin-vue": ^1.2.1
+    es-module-lexer: ^0.6.0
     glob-promise: ^4.1.0
     vite-plugin-mdx: ^3.5.1
   peerDependencies:


### PR DESCRIPTION
Fix for #38

Needs thought around how we keep track of stories, instead of having to hardcode `/\.stories\.(t|j)sx?$/.test(id)`