### PR TITLE
Add remark about autoreload for stories to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ yarn add --dev storybook-builder-vite
 In your `main.js` configuration file,
 set `core: { builder: "storybook-builder-vite" }`.
 
+> For autoreload of stories to work, they need to have `.stories.tsx` file suffix.
+> See also [#53](https://github.com/eirslett/storybook-builder-vite/pull/53)
+
 ### Customize Vite config
 
 The builder will _not_ read your `vite.config.js` file by default.


### PR DESCRIPTION
Today I spent some time trying to figure out why autoreload for story files doesn't work. This pull request adds remark to README about naming of story files for autoreload to work.

This is related to: https://github.com/eirslett/storybook-builder-vite/pull/53