### PR TITLE
Allow passing options to vite-plugin-svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ The `configType` variable will be either `"DEVELOPMENT"` or `"PRODUCTION"`.
 
 The function should return the updated Vite configuration.
 
+### Svelte Customization
+
+When using this builder with Svelte, your `.storybook/main.js` (or equivalent)
+can contain a `svelteOptions` object to pass custom options to
+[`vite-plugin-svelte`](https://github.com/sveltejs/vite-plugin-svelte/tree/main/packages/vite-plugin-svelte):
+
+```javascript
+const preprocess = require('svelte-preprocess');
+
+module.exports = {
+    svelteOptions: {
+        preprocess: preprocess({
+            typescript: true,
+            postcss: true,
+            sourceMap: true
+        }),
+    },
+};
+````
+
 ## Note about working directory
 
 The builder will by default enable Vite's [server.fsServe.strict](https://vitejs.dev/config/#server-fsserve-strict)

--- a/packages/storybook-builder-vite/vite-config.js
+++ b/packages/storybook-builder-vite/vite-config.js
@@ -7,7 +7,7 @@ const { codeGeneratorPlugin } = require('./code-generator-plugin');
 const { injectExportOrderPlugin } = require('./inject-export-order-plugin');
 
 module.exports.pluginConfig = function pluginConfig(options, type) {
-    const { framework } = options;
+    const { framework, svelteOptions } = options;
     const plugins = [
         codeGeneratorPlugin(options),
         mockCoreJs(),
@@ -33,7 +33,7 @@ module.exports.pluginConfig = function pluginConfig(options, type) {
     if (framework === 'svelte') {
         try {
             const sveltePlugin = require('@sveltejs/vite-plugin-svelte').svelte;
-            plugins.push(sveltePlugin());
+            plugins.push(sveltePlugin(svelteOptions));
         } catch (err) {
             if (err.code !== 'MODULE_NOT_FOUND') {
                 throw new Error(


### PR DESCRIPTION
Required to use svelte-preprocess for Typescript, PostCSS, etc. support inside Svelte components. This uses the same `svelteOptions` key used with other builders. 