### PR TITLE
Attempt to add support for CSF3 render preset

### DIFF
--- a/packages/example-react/.storybook/main.js
+++ b/packages/example-react/.storybook/main.js
@@ -19,4 +19,7 @@ module.exports = {
         // customize the Vite config here
         return config;
     },
+    features: {
+        previewCsfV3: true,
+    },
 };

--- a/packages/example-react/.storybook/main.js
+++ b/packages/example-react/.storybook/main.js
@@ -19,7 +19,4 @@ module.exports = {
         // customize the Vite config here
         return config;
     },
-    features: {
-        previewCsfV3: true,
-    },
 };

--- a/packages/example-react/.storybook/main.js
+++ b/packages/example-react/.storybook/main.js
@@ -12,9 +12,6 @@ module.exports = {
     core: {
         builder: 'storybook-builder-vite',
     },
-    features: {
-      storyStoreV7: true,
-    },
     async viteFinal(config, { configType }) {
         // customize the Vite config here
         return config;

--- a/packages/example-react/stories/Button.stories.jsx
+++ b/packages/example-react/stories/Button.stories.jsx
@@ -1,7 +1,6 @@
 import { Button } from './Button';
 
 export default {
-    title: 'Example/Button',
     component: Button,
     argTypes: {
         backgroundColor: { control: 'color' },

--- a/packages/example-react/stories/Button.stories.jsx
+++ b/packages/example-react/stories/Button.stories.jsx
@@ -8,24 +8,25 @@ export default {
     },
 };
 
-const Template = (args) => <Button {...args} />;
+export const Primary = {
+    args: {
+        primary: true,
+        label: 'Button',
+    }
+}
 
-export const Primary = Template.bind({});
-Primary.args = {
-    primary: true,
-    label: 'Button',
-};
+export const Secondary = {
+    args: {
+        label: 'Button',
+    }
+}
 
-export const Secondary = Template.bind({});
-Secondary.args = {
-    label: 'Button',
-};
-
-export const Large = Template.bind({});
-Large.args = {
-    size: 'large',
-    label: 'Button',
-};
+export const Large = {
+    args: {
+        size: 'large',
+        label: 'Button',
+    }
+}
 
 export const Small = {
     args: {

--- a/packages/example-react/stories/Button.stories.jsx
+++ b/packages/example-react/stories/Button.stories.jsx
@@ -27,8 +27,9 @@ Large.args = {
     label: 'Button',
 };
 
-export const Small = Template.bind({});
-Small.args = {
-    size: 'small',
-    label: 'Button',
+export const Small = {
+    args: {
+        size: 'small',
+        label: 'Button',
+    }
 };

--- a/packages/storybook-builder-vite/codegen-iframe-script.js
+++ b/packages/storybook-builder-vite/codegen-iframe-script.js
@@ -59,7 +59,7 @@ module.exports.generateIframeScriptCode =
         .map((entry) => `// preview entry\nimport '${entry}';`)
         .join('\n')} */
 
-    import { addDecorator, addParameters, addLoader, addArgTypesEnhancer, addArgsEnhancer } from '@storybook/client-api';
+    import { addDecorator, addParameters, addLoader, addArgTypesEnhancer, addArgsEnhancer, setGlobalRender } from '@storybook/client-api';
     import { logger } from '@storybook/client-logger';
     ${absoluteFilesToImport(configEntries, 'config')}
     ${absoluteFilesToImport(storyEntries, 'story')}
@@ -97,6 +97,8 @@ module.exports.generateIframeScriptCode =
           case 'decorateStory':
           case 'renderToDOM': {
             return null; // This key is not handled directly in v6 mode.
+          case 'render': {
+            return setGlobalRender(value);
           }
           default: {
             // eslint-disable-next-line prefer-template

--- a/packages/storybook-builder-vite/codegen-iframe-script.js
+++ b/packages/storybook-builder-vite/codegen-iframe-script.js
@@ -97,6 +97,7 @@ module.exports.generateIframeScriptCode =
           case 'decorateStory':
           case 'renderToDOM': {
             return null; // This key is not handled directly in v6 mode.
+          }
           case 'render': {
             return setGlobalRender(value);
           }


### PR DESCRIPTION
Issue: N/A

## What I did

- [x] Add a render preset similar to how it's done in webpack https://github.com/storybookjs/storybook/blob/next/lib/builder-webpack4/src/preview/virtualModuleEntry.template.js#L36
- [x] Update the react example to test it out

## What I need

Trying to test it out, but the example is failing with the error:

```
Uncaught SyntaxError: The requested module '/node_modules/.vite/@storybook_client-api.js?v=c67b5dc5' does not provide an export named 'setGlobalRender'
```

This is strange because AFAIK that export exists, even in 6.3