### PR TITLE
Inject storybook environment variables

### DIFF
--- a/packages/example-react/stories/EnvironmentVariables.jsx
+++ b/packages/example-react/stories/EnvironmentVariables.jsx
@@ -1,0 +1,11 @@
+
+export function EnvironmentVariables() {
+  return (
+    <div>
+      <h1>import.meta.env:</h1>
+      <div>{JSON.stringify(import.meta.env, null, 2)}</div>
+      <h1>import.meta.env.STORYBOOK:</h1>
+      <div>{import.meta.env.STORYBOOK}</div>
+    </div>
+  )
+}

--- a/packages/example-react/stories/EnvironmentVariables.jsx
+++ b/packages/example-react/stories/EnvironmentVariables.jsx
@@ -2,9 +2,9 @@
 export function EnvironmentVariables() {
   return (
     <div>
-      <h1>import.meta.env:</h1>
+      <h1>import . meta . env:</h1>
       <div>{JSON.stringify(import.meta.env, null, 2)}</div>
-      <h1>import.meta.env.STORYBOOK:</h1>
+      <h1>import . meta . env . STORYBOOK:</h1>
       <div>{import.meta.env.STORYBOOK}</div>
     </div>
   )

--- a/packages/example-react/stories/EnvironmentVariables.stories.jsx
+++ b/packages/example-react/stories/EnvironmentVariables.stories.jsx
@@ -1,0 +1,8 @@
+import {EnvironmentVariables} from './EnvironmentVariables';
+
+export default {
+  title: 'Environment Variables',
+  component: EnvironmentVariables
+};
+
+export const Info = () => <EnvironmentVariables/>;

--- a/packages/example-svelte/stories/EnvironmentVariables.stories.svelte
+++ b/packages/example-svelte/stories/EnvironmentVariables.stories.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { Meta, Template, Story } from "@storybook/addon-svelte-csf";
+  import EnvironmentVariables from "./EnvironmentVariables.svelte";
+</script>
+
+<Meta
+  title="Environment Variables"
+  component={EnvironmentVariables}
+/>
+
+<Template>
+  <EnvironmentVariables />
+</Template>
+
+<Story name="Info" />

--- a/packages/example-svelte/stories/EnvironmentVariables.svelte
+++ b/packages/example-svelte/stories/EnvironmentVariables.svelte
@@ -1,0 +1,13 @@
+<script>
+  export const env = JSON.stringify(import.meta.env, null, 2);
+  export const storybook = import.meta.env.STORYBOOK;
+</script>
+
+
+<div>
+  <h1>import.meta.env:</h1>
+  <div>{env}</div>
+  <h1>import.meta.env.STORYBOOK:</h1>
+  <div>{storybook}</div>
+</div>
+

--- a/packages/example-svelte/stories/EnvironmentVariables.svelte
+++ b/packages/example-svelte/stories/EnvironmentVariables.svelte
@@ -5,9 +5,9 @@
 
 
 <div>
-  <h1>import.meta.env:</h1>
+  <h1>impor . meta . env:</h1>
   <div>{env}</div>
-  <h1>import.meta.env.STORYBOOK:</h1>
+  <h1>import . meta . env . STORYBOOK:</h1>
   <div>{storybook}</div>
 </div>
 

--- a/packages/example-vue/stories/EnvironmentVariables.stories.js
+++ b/packages/example-vue/stories/EnvironmentVariables.stories.js
@@ -1,0 +1,11 @@
+import EnvironmentVariables from './EnvironmentVariables.vue';
+
+export default {
+  title: 'Environment Variables',
+  component: EnvironmentVariables
+};
+
+export const Info = () => ({
+  components: { EnvironmentVariables },
+  template: '<EnvironmentVariables />',
+});

--- a/packages/example-vue/stories/EnvironmentVariables.vue
+++ b/packages/example-vue/stories/EnvironmentVariables.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
-      <h1>import.meta.env:</h1>
+      <h1>import . meta . env:</h1>
       <div>{{env}}</div>
-      <h1>import.meta.env.STORYBOOK:</h1>
+      <h1>import . meta . env . STORYBOOK:</h1>
       <div>{{storybook}}</div>
     </div>
 </template>

--- a/packages/example-vue/stories/EnvironmentVariables.vue
+++ b/packages/example-vue/stories/EnvironmentVariables.vue
@@ -1,0 +1,22 @@
+<template>
+    <div>
+      <h1>import.meta.env:</h1>
+      <div>{{env}}</div>
+      <h1>import.meta.env.STORYBOOK:</h1>
+      <div>{{storybook}}</div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'env-vars',
+    computed: {
+      env() {
+        return JSON.stringify(import.meta.env, null, 2);
+      },
+      storybook() {
+        return import.meta.env.STORYBOOK;
+      }
+    }
+};
+</script>

--- a/packages/storybook-builder-vite/build.js
+++ b/packages/storybook-builder-vite/build.js
@@ -1,8 +1,13 @@
 const path = require('path');
+const { stringifyProcessEnvs } = require('./envs');
 const { pluginConfig } = require('./vite-config');
 const { build: viteBuild } = require('vite');
 
 module.exports.build = async function build(options) {
+    const { presets } = options;
+    const envsRaw = await presets.apply('env');
+    const envs = stringifyProcessEnvs(envsRaw);
+
     const config = {
         configFile: false,
         root: path.resolve(options.configDir, '..'),
@@ -11,6 +16,7 @@ module.exports.build = async function build(options) {
             emptyOutDir: false, // do not clean before running Vite build - Storybook has already added assets in there!
             sourcemap: true,
         },
+        define: envs,
         resolve: {
             alias: {
                 vue: 'vue/dist/vue.esm-bundler.js',
@@ -19,7 +25,7 @@ module.exports.build = async function build(options) {
         plugins: pluginConfig(options, 'build'),
     };
 
-    const finalConfig = await options.presets.apply(
+    const finalConfig = await presets.apply(
         'viteFinal',
         config,
         options

--- a/packages/storybook-builder-vite/envs.js
+++ b/packages/storybook-builder-vite/envs.js
@@ -1,0 +1,22 @@
+const { stringifyEnvs } = require('@storybook/core-common')
+
+/**
+* Customized version of stringifyProcessEnvs from @storybook/core-common which
+* uses import.meta.env instead of process.env
+*/
+module.exports.stringifyProcessEnvs = function stringifyProcessEnvs(raw) {
+  const envs = Object.entries(raw).reduce(
+    (acc, [key, value]) => {
+      acc[`import.meta.env.${key}`] = JSON.stringify(value);
+      return acc;
+    },
+    {
+      // Default fallback
+      'process.env.XSTORYBOOK_EXAMPLE_APP': '""',
+    }
+  );
+  // support destructuring like
+  // const { foo } = import.meta.env;
+  envs['import.meta.env'] = JSON.stringify(stringifyEnvs(raw));
+  return envs;
+}

--- a/packages/storybook-builder-vite/vite-server.js
+++ b/packages/storybook-builder-vite/vite-server.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const {stringifyEnvs} = require('@storybook/core-common')
 const { optimizeDeps } = require('./optimizeDeps');
 const { createServer } = require('vite');
 const { pluginConfig } = require('./vite-config');
@@ -9,6 +10,8 @@ module.exports.createViteServer = async function createViteServer(
 ) {
     const { port, presets } = options;
     const root = path.resolve(options.configDir, '..');
+    const envsRaw = await presets.apply('env');
+    const envs = stringifyProcessEnvs(envsRaw);
 
     const defaultConfig = {
         configFile: false,
@@ -24,6 +27,7 @@ module.exports.createViteServer = async function createViteServer(
                 strict: true,
             },
         },
+        define: envs,
         resolve: {
             alias: {
                 vue: 'vue/dist/vue.esm-bundler.js',
@@ -40,3 +44,25 @@ module.exports.createViteServer = async function createViteServer(
     );
     return createServer(finalConfig);
 };
+
+
+/**
+ * Customized version of stringifyProcessEnvs from @storybook/core-common which
+ * uses import.meta.env instead of process.env
+ */
+ function stringifyProcessEnvs(raw) {
+    const envs = Object.entries(raw).reduce(
+        (acc, [key, value]) => {
+          acc[`import.meta.env.${key}`] = JSON.stringify(value);
+          return acc;
+        },
+        {
+          // Default fallback
+          'process.env.XSTORYBOOK_EXAMPLE_APP': '""',
+        }
+      );
+    // support destructuring like
+  // const { foo } = import.meta.env;
+  envs['import.meta.env'] = JSON.stringify(stringifyEnvs(raw));
+  return envs;
+}

--- a/packages/storybook-builder-vite/vite-server.js
+++ b/packages/storybook-builder-vite/vite-server.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const {stringifyEnvs} = require('@storybook/core-common')
+const {stringifyProcessEnvs} = require('./envs');
 const { optimizeDeps } = require('./optimizeDeps');
 const { createServer } = require('vite');
 const { pluginConfig } = require('./vite-config');
@@ -46,23 +46,4 @@ module.exports.createViteServer = async function createViteServer(
 };
 
 
-/**
- * Customized version of stringifyProcessEnvs from @storybook/core-common which
- * uses import.meta.env instead of process.env
- */
- function stringifyProcessEnvs(raw) {
-    const envs = Object.entries(raw).reduce(
-        (acc, [key, value]) => {
-          acc[`import.meta.env.${key}`] = JSON.stringify(value);
-          return acc;
-        },
-        {
-          // Default fallback
-          'process.env.XSTORYBOOK_EXAMPLE_APP': '""',
-        }
-      );
-    // support destructuring like
-  // const { foo } = import.meta.env;
-  envs['import.meta.env'] = JSON.stringify(stringifyEnvs(raw));
-  return envs;
-}
+


### PR DESCRIPTION
Fixes #104.

This injects storybook environment variables through the `define` config of vite, similar to what the webpack builder does using the `DefinePlugin`.  I needed to create a customized version of one of the core storybook functions, since it assumes that `process.env` is going to be used, whereas with vite we use `import.meta.env`.  

I also added example stories in react, vue, and svelte (my first time writing vue and svelte!).  They're ugly, but they show that the STORYBOOK environment variable is being provided correctly (it wasn't previously).

Before:
![image](https://user-images.githubusercontent.com/4616705/135190381-dfaec2cc-a7e5-43dc-8412-300d69bac2f2.png)



After:
![image](https://user-images.githubusercontent.com/4616705/135190265-c3d45307-fc62-4731-8809-8624ff958de1.png)
