### PR TITLE
Fix rollup warning about sourcemaps from inject-export-order-plugin

### DIFF
--- a/packages/storybook-builder-vite/inject-export-order-plugin.js
+++ b/packages/storybook-builder-vite/inject-export-order-plugin.js
@@ -17,8 +17,11 @@ module.exports.injectExportOrderPlugin = {
 
         const orderedExports = exports.filter((e) => e !== 'default');
 
-        return `${code};\nexport const __namedExportsOrder = ${JSON.stringify(
-            orderedExports
-        )};`;
+        return {
+            code: `${code};\nexport const __namedExportsOrder = ${JSON.stringify(
+                orderedExports
+            )};`,
+            map: null,
+        };
     },
 };


### PR DESCRIPTION
When building storybook with this builder, I get many warnings like:

```
Sourcemap is likely to be incorrect: a plugin (storybook-vite-inject-export-order-plugin) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
```

This PR returns `map: null`, which the rollup documentation says:

>If the transformation does not move code, you can preserve existing sourcemaps by returning null:

I think this is okay to do, because this transform only adds code to the end, and there's nothing in the original to map it back to, so it should be fine to leave the existing sourcemaps how they are, I think.

I've tested out this change in my own app by changing the `node_modules`, and the warnings are no longer shown.  