### PR TITLE
Update storybook in examples

### DIFF
--- a/packages/example-react/.storybook/main.js
+++ b/packages/example-react/.storybook/main.js
@@ -1,4 +1,5 @@
 module.exports = {
+    framework: "@storybook/react",
     stories: [
         '../stories/**/*.stories.mdx',
         '../stories/**/*.stories.@(js|jsx|ts|tsx)',

--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -15,10 +15,10 @@
         "react-dom": "17.0.2"
     },
     "devDependencies": {
-        "@storybook/addon-a11y": "^6.4.0-beta.14",
-        "@storybook/addon-docs": "^6.4.0-beta.14",
-        "@storybook/addon-essentials": "^6.4.0-beta.14",
-        "@storybook/react": "^6.4.0-beta.14",
+        "@storybook/addon-a11y": "^6.4.0-beta.19",
+        "@storybook/addon-docs": "^6.4.0-beta.19",
+        "@storybook/addon-essentials": "^6.4.0-beta.19",
+        "@storybook/react": "^6.4.0-beta.19",
         "storybook-builder-vite": "workspace:*",
         "vite": "^2.4.1"
     }

--- a/packages/example-svelte/.storybook/main.js
+++ b/packages/example-svelte/.storybook/main.js
@@ -1,4 +1,5 @@
 module.exports = {
+    framework: '@storybook/svelte',
     stories: [
         '../stories/**/*.stories.mdx',
         '../stories/**/*.stories.@(js|jsx|ts|tsx|svelte)',

--- a/packages/example-svelte/package.json
+++ b/packages/example-svelte/package.json
@@ -14,11 +14,11 @@
         "svelte": "^3.38.3"
     },
     "devDependencies": {
-        "@storybook/addon-actions": "^6.4.0-beta.14",
-        "@storybook/addon-essentials": "^6.4.0-beta.14",
-        "@storybook/addon-links": "^6.4.0-beta.14",
+        "@storybook/addon-actions": "^6.4.0-beta.19",
+        "@storybook/addon-essentials": "^6.4.0-beta.19",
+        "@storybook/addon-links": "^6.4.0-beta.19",
         "@storybook/addon-svelte-csf": "^1.1.0",
-        "@storybook/svelte": "^6.4.0-beta.14",
+        "@storybook/svelte": "^6.4.0-beta.19",
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",
         "storybook-builder-vite": "workspace:*",
         "vite": "^2.4.1"

--- a/packages/example-vue/.storybook/main.js
+++ b/packages/example-vue/.storybook/main.js
@@ -1,4 +1,5 @@
 module.exports = {
+    framework: '@storybook/vue3',
     stories: [
         '../stories/**/*.stories.mdx',
         '../stories/**/*.stories.@(js|jsx|ts|tsx)',

--- a/packages/example-vue/package.json
+++ b/packages/example-vue/package.json
@@ -14,9 +14,9 @@
         "vue": "^3.1.4"
     },
     "devDependencies": {
-        "@storybook/addon-a11y": "^6.4.0-beta.14",
-        "@storybook/addon-essentials": "^6.4.0-beta.14",
-        "@storybook/vue3": "^6.4.0-beta.14",
+        "@storybook/addon-a11y": "^6.4.0-beta.19",
+        "@storybook/addon-essentials": "^6.4.0-beta.19",
+        "@storybook/vue3": "^6.4.0-beta.19",
         "@vitejs/plugin-vue": "^1.2.4",
         "storybook-builder-vite": "workspace:*",
         "vite": "^2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1764,10 +1764,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@base2/pretty-print-object@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@base2/pretty-print-object@npm:1.0.0"
-  checksum: cadfeaf0bb23808d8e22e250fa9e7b5475adc33ea04d1d98feb9ce27fc00ad139937b00a5d6add668a12d56bb6235bdfbe528c39102331b6758dd2c78eabbb39
+"@base2/pretty-print-object@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@base2/pretty-print-object@npm:1.0.1"
+  checksum: 59ff4e0071407b06d793d4d57f9fed618c09347942c775e98ac16bc8d9c7c7c9b209bc3393d78082b47c5526165ac3f6fb05ea20a04823ffe243bea0d611678b
   languageName: node
   linkType: hard
 
@@ -2182,18 +2182,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-a11y@npm:^6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/addon-a11y@npm:6.4.0-beta.14"
+"@storybook/addon-a11y@npm:^6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/addon-a11y@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/channels": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/components": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/channels": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/components": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.0-beta.14
+    "@storybook/theming": 6.4.0-beta.19
     axe-core: ^4.2.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -2210,20 +2210,20 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 176b1377409f011cedfab0318300e9d9b5c5ae93ae7c1bf224a481ef12f5631750d0891dfeb41678bfbce099bd86b916dd5d6f72864bbbb60ea6940bdf97235c
+  checksum: add72723b3593576a56d5e0940557986d852ea2190f710f258e50c85abb552720c2f9b81334f725716cd9746e2c8068b47c683ed6d86ce8d3dae7343d3ca3933
   languageName: node
   linkType: hard
 
-"@storybook/addon-actions@npm:6.4.0-beta.14, @storybook/addon-actions@npm:^6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/addon-actions@npm:6.4.0-beta.14"
+"@storybook/addon-actions@npm:6.4.0-beta.19, @storybook/addon-actions@npm:^6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/addon-actions@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/components": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/components": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.0-beta.14
+    "@storybook/theming": 6.4.0-beta.19
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
@@ -2232,6 +2232,7 @@ __metadata:
     prop-types: ^15.7.2
     react-inspector: ^5.1.0
     regenerator-runtime: ^0.13.7
+    telejson: ^5.3.2
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
     uuid-browser: ^3.1.0
@@ -2243,21 +2244,21 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: bae6e24977c3b4d68f06f1a3d679021577159b539df3aac4e70f9acc45088bb415c1b932dc1c807a9cbea2674a9bac6cc27907caed197c5d1cefcfaf837cc903
+  checksum: b6d01c3fd42996edee11e341ad39ac07c387190a64cf7ef624a9e8a52f22efd94fed4698c00d4b123fd5196aff5ada533be5c19d9a7441f9a07736047ea155ec
   languageName: node
   linkType: hard
 
-"@storybook/addon-backgrounds@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/addon-backgrounds@npm:6.4.0-beta.14"
+"@storybook/addon-backgrounds@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/addon-backgrounds@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/components": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/components": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.0-beta.14
+    "@storybook/theming": 6.4.0-beta.19
     core-js: ^3.8.2
     global: ^4.4.0
     memoizerific: ^1.11.3
@@ -2272,23 +2273,23 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 91c196f5e9d4b3d6bb4cc2f40ce9e86fcc45368590aa460c015f7c4728b7f6524cc58909ba7c62c969835f69f79fe6cb64f477f8dbeaae7ab9674685b317a423
+  checksum: 0eb7db56f0aac1ae9e5f3db228224630a9a800d509d092c0186f7fd6e3ecb9a607ad19c346be96d63d924c6826d278e43fd8e6a7c226c7d5b179eaa3a29bdeba
   languageName: node
   linkType: hard
 
-"@storybook/addon-controls@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/addon-controls@npm:6.4.0-beta.14"
+"@storybook/addon-controls@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/addon-controls@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/components": 6.4.0-beta.14
-    "@storybook/core-common": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/components": 6.4.0-beta.19
+    "@storybook/core-common": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/node-logger": 6.4.0-beta.14
-    "@storybook/store": 6.4.0-beta.14
-    "@storybook/theming": 6.4.0-beta.14
+    "@storybook/node-logger": 6.4.0-beta.19
+    "@storybook/store": 6.4.0-beta.19
+    "@storybook/theming": 6.4.0-beta.19
     core-js: ^3.8.2
     lodash: ^4.17.20
     ts-dedent: ^2.0.0
@@ -2300,13 +2301,13 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: f659cf40b9b2bf7fdab80956fb805e7c94b8e29c24d4c9ef05e4ae5c65bda558194ad33abcf7bfa0bb98e5753c1eb39b1786cb0a0a1ea19685631a48016ecc0f
+  checksum: 58d318b287a5608186f420ef529a8406c3ca523dd6981111b9273171b5b41fbd393d5f8e0ef6c5f482813562be04b14d928e8f0bb2b18ede4122d41ca3c20d73
   languageName: node
   linkType: hard
 
-"@storybook/addon-docs@npm:6.4.0-beta.14, @storybook/addon-docs@npm:^6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/addon-docs@npm:6.4.0-beta.14"
+"@storybook/addon-docs@npm:6.4.0-beta.19, @storybook/addon-docs@npm:^6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/addon-docs@npm:6.4.0-beta.19"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/generator": ^7.12.11
@@ -2317,22 +2318,21 @@ __metadata:
     "@mdx-js/loader": ^1.6.22
     "@mdx-js/mdx": ^1.6.22
     "@mdx-js/react": ^1.6.22
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/builder-webpack4": 6.4.0-beta.14
-    "@storybook/client-api": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/components": 6.4.0-beta.14
-    "@storybook/core": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/builder-webpack4": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/components": 6.4.0-beta.19
+    "@storybook/core": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/csf-tools": 6.4.0-beta.14
-    "@storybook/node-logger": 6.4.0-beta.14
-    "@storybook/postinstall": 6.4.0-beta.14
-    "@storybook/preview-web": 6.4.0-beta.14
-    "@storybook/source-loader": 6.4.0-beta.14
-    "@storybook/store": 6.4.0-beta.14
-    "@storybook/theming": 6.4.0-beta.14
+    "@storybook/csf-tools": 6.4.0-beta.19
+    "@storybook/node-logger": 6.4.0-beta.19
+    "@storybook/postinstall": 6.4.0-beta.19
+    "@storybook/preview-web": 6.4.0-beta.19
+    "@storybook/source-loader": 6.4.0-beta.19
+    "@storybook/store": 6.4.0-beta.19
+    "@storybook/theming": 6.4.0-beta.19
     acorn: ^7.4.1
     acorn-jsx: ^5.3.1
     acorn-walk: ^7.2.0
@@ -2349,19 +2349,19 @@ __metadata:
     p-limit: ^3.1.0
     prettier: ^2.2.1
     prop-types: ^15.7.2
-    react-element-to-jsx-string: ^14.3.2
+    react-element-to-jsx-string: ^14.3.4
     regenerator-runtime: ^0.13.7
     remark-external-links: ^8.0.0
     remark-slug: ^6.0.0
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
   peerDependencies:
-    "@storybook/angular": 6.4.0-beta.14
-    "@storybook/html": 6.4.0-beta.14
-    "@storybook/react": 6.4.0-beta.14
-    "@storybook/vue": 6.4.0-beta.14
-    "@storybook/vue3": 6.4.0-beta.14
-    "@storybook/web-components": 6.4.0-beta.14
+    "@storybook/angular": 6.4.0-beta.19
+    "@storybook/html": 6.4.0-beta.19
+    "@storybook/react": 6.4.0-beta.19
+    "@storybook/vue": 6.4.0-beta.19
+    "@storybook/vue3": 6.4.0-beta.19
+    "@storybook/web-components": 6.4.0-beta.19
     lit: ^2.0.0-rc.1
     lit-html: ^1.4.1 || ^2.0.0-rc.3
     react: ^16.8.0 || ^17.0.0
@@ -2399,32 +2399,32 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 7662c277175565da452a8c4215f78a3375332f005cac092b8aea88a0381b7a3880020b3c13f11b7d40df36290ec9dcc7456767b929e6783ae9a5abac38bc352d
+  checksum: be67a54d75318ebc49653832ba6c0de3f440eb6115ba6e185adbab5bd19846d5df4904f540d409bb92b711be4289d5bd99a38b1fe2349657a09ea2ab82959fce
   languageName: node
   linkType: hard
 
-"@storybook/addon-essentials@npm:^6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/addon-essentials@npm:6.4.0-beta.14"
+"@storybook/addon-essentials@npm:^6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/addon-essentials@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addon-actions": 6.4.0-beta.14
-    "@storybook/addon-backgrounds": 6.4.0-beta.14
-    "@storybook/addon-controls": 6.4.0-beta.14
-    "@storybook/addon-docs": 6.4.0-beta.14
-    "@storybook/addon-measure": 6.4.0-beta.14
-    "@storybook/addon-outline": 6.4.0-beta.14
-    "@storybook/addon-toolbars": 6.4.0-beta.14
-    "@storybook/addon-viewport": 6.4.0-beta.14
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/node-logger": 6.4.0-beta.14
+    "@storybook/addon-actions": 6.4.0-beta.19
+    "@storybook/addon-backgrounds": 6.4.0-beta.19
+    "@storybook/addon-controls": 6.4.0-beta.19
+    "@storybook/addon-docs": 6.4.0-beta.19
+    "@storybook/addon-measure": 6.4.0-beta.19
+    "@storybook/addon-outline": 6.4.0-beta.19
+    "@storybook/addon-toolbars": 6.4.0-beta.19
+    "@storybook/addon-viewport": 6.4.0-beta.19
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/node-logger": 6.4.0-beta.19
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
   peerDependencies:
     "@babel/core": ^7.9.6
-    "@storybook/vue": 6.4.0-beta.14
-    "@storybook/web-components": 6.4.0-beta.14
+    "@storybook/vue": 6.4.0-beta.19
+    "@storybook/web-components": 6.4.0-beta.19
     babel-loader: ^8.0.0
     lit-html: ^1.4.1 || ^2.0.0-rc.3
     react: ^16.8.0 || ^17.0.0
@@ -2443,19 +2443,19 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 35cd638bf9a8a7e206b84ad1d5306917785bf3d15d6d269cfcb62acdfa51ffb306dc1b935679a29980bd65324ac5f827059e543d0fafb1ced434b050c17ec193
+  checksum: cc749db40aa34f58c6e89b04b801b0ce7941ec80459fb3b07dfccb732cf88f6d2e118b33e74dbee8580bb4fbcc8a8acd129980c19f027961c280307f77ce9ecb
   languageName: node
   linkType: hard
 
-"@storybook/addon-links@npm:^6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/addon-links@npm:6.4.0-beta.14"
+"@storybook/addon-links@npm:^6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/addon-links@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/router": 6.4.0-beta.14
+    "@storybook/router": 6.4.0-beta.19
     "@types/qs": ^6.9.5
     core-js: ^3.8.2
     global: ^4.4.0
@@ -2471,19 +2471,19 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: ce929ed2647472f0c2d802a8f3e76f9e94ac2564653b1ff89a347fabe1d2ff8c1710b0e15134847b4c3b3db16e1a3081d191aed4bc387954837e8b28d1b384fe
+  checksum: f978a91b820f3a9851b423982b4e2045021097c288e9d1983e104e42292eabffb241b1ca08efa1ebe99c5d299b6f975823ae0c1c68b692372de98f9552914e80
   languageName: node
   linkType: hard
 
-"@storybook/addon-measure@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/addon-measure@npm:6.4.0-beta.14"
+"@storybook/addon-measure@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/addon-measure@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/components": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/components": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -2495,19 +2495,19 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 13f3356feb0789c299386ba59ab83c3027307a36f82daacb824f912fc4cc071b545589e04c3108a83a38fee4ed4efa45be61d641165139ed5888b43c18a8a223
+  checksum: c0f904c2e0179403e1d64e22af2eb69ebc548bc5a66a0e46bd79611ab310f7066cc61f610593d8654087426d7fae280457e988af92fd0ec965498cbbe5bdfc15
   languageName: node
   linkType: hard
 
-"@storybook/addon-outline@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/addon-outline@npm:6.4.0-beta.14"
+"@storybook/addon-outline@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/addon-outline@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/components": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/components": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -2521,7 +2521,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: bb8138079a9b49c4b59af1ee017e09eb7a8db4ceb9b9f5f8f0700e473c9a25022927c96e189e802acaa0437167e9891c1b575b5986fff9eae0ff260a2b566fb7
+  checksum: 7e628ae487f154cd0aaefdaac31fed6fc02c3b4eb147345bd0db9ccbb809e114bd130fe36d84ed2e3b5b9ff90d0718250dccd8936105db6188b34daa4945eac8
   languageName: node
   linkType: hard
 
@@ -2554,14 +2554,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-toolbars@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/addon-toolbars@npm:6.4.0-beta.14"
+"@storybook/addon-toolbars@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/addon-toolbars@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/components": 6.4.0-beta.14
-    "@storybook/theming": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/components": 6.4.0-beta.19
+    "@storybook/theming": 6.4.0-beta.19
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
   peerDependencies:
@@ -2572,20 +2572,20 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 9fa87828afad1de97cdd8e81cb1a84aad2d637625b7cb744756ddf00c1b08e578fea4b1f0344a5e2b73482b1fa18ee8a48be03b4188b2308a24015c264ff2680
+  checksum: 2833c2275741f49cc5f3b2132d52f4c324f961a749f2a8a500850a8e46dae5e3af44f84ca73ed612a47aaaf99f4773d0c95ee8f184b567b53f88a14053eb80d4
   languageName: node
   linkType: hard
 
-"@storybook/addon-viewport@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/addon-viewport@npm:6.4.0-beta.14"
+"@storybook/addon-viewport@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/addon-viewport@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/components": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
-    "@storybook/theming": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/components": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
+    "@storybook/theming": 6.4.0-beta.19
     core-js: ^3.8.2
     global: ^4.4.0
     memoizerific: ^1.11.3
@@ -2599,21 +2599,21 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: dee47b4896abacea57f50e2fb6624afc94606f584468bd6ed793f5f3dff64dea2b4df5b4a36e749fc0ea383d213459ad4d742cc7bc0a3a6e2b0fc9dc0f638456
+  checksum: faff04cdc46f67926e5064eed0cd7cc88f0cdb542ed9bdca1301e1516936e505400c92e4b260a777c02e82d4a2b18c1a8f8ce1ebdae0301a4164b69accbaa6c0
   languageName: node
   linkType: hard
 
-"@storybook/addons@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/addons@npm:6.4.0-beta.14"
+"@storybook/addons@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/addons@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/channels": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/channels": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/router": 6.4.0-beta.14
-    "@storybook/theming": 6.4.0-beta.14
+    "@storybook/router": 6.4.0-beta.19
+    "@storybook/theming": 6.4.0-beta.19
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -2621,22 +2621,22 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: d8f6e9d4b1e5fafd2b007c66d9f8812e5b33a22b60ca1efa0f2916c25d8cdc72e0170bc0cde5c3c3eea78c170e2191f4858b786095389d9018c2dba9c5a93dd9
+  checksum: 36221de288bde0b548e1f2ff69ab6848885a5336b6c30c7f4275cd2b89c488019939a9514c78b3fb6453e094175a29ae6c17fc07cd32824925eb8ae84a8ba943
   languageName: node
   linkType: hard
 
-"@storybook/api@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/api@npm:6.4.0-beta.14"
+"@storybook/api@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/api@npm:6.4.0-beta.19"
   dependencies:
     "@reach/router": ^1.3.4
-    "@storybook/channels": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/channels": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/router": 6.4.0-beta.14
+    "@storybook/router": 6.4.0-beta.19
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.4.0-beta.14
+    "@storybook/theming": 6.4.0-beta.19
     "@types/reach__router": ^1.3.7
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
@@ -2652,13 +2652,13 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 9cade22392e1f430382247e4554f8d20430b1b3e2e6a708ff2b28d8e0bdf15fa3d3fe5620506080edcf2cdad393a7a30a1860389890660c15dabee039f6811bb
+  checksum: 5d6e96a31cee4f2d85d1725b28eb72e1539538234d19678ffe6177977f239ada59125212025004762aa45d7a81e43f35508e0be26318adcff189f5dd2dd5305d
   languageName: node
   linkType: hard
 
-"@storybook/builder-webpack4@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/builder-webpack4@npm:6.4.0-beta.14"
+"@storybook/builder-webpack4@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/builder-webpack4@npm:6.4.0-beta.19"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -2681,22 +2681,22 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/channel-postmessage": 6.4.0-beta.14
-    "@storybook/channels": 6.4.0-beta.14
-    "@storybook/client-api": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/components": 6.4.0-beta.14
-    "@storybook/core-common": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
-    "@storybook/node-logger": 6.4.0-beta.14
-    "@storybook/preview-web": 6.4.0-beta.14
-    "@storybook/router": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/channel-postmessage": 6.4.0-beta.19
+    "@storybook/channels": 6.4.0-beta.19
+    "@storybook/client-api": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/components": 6.4.0-beta.19
+    "@storybook/core-common": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
+    "@storybook/node-logger": 6.4.0-beta.19
+    "@storybook/preview-web": 6.4.0-beta.19
+    "@storybook/router": 6.4.0-beta.19
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.0-beta.14
-    "@storybook/theming": 6.4.0-beta.14
-    "@storybook/ui": 6.4.0-beta.14
+    "@storybook/store": 6.4.0-beta.19
+    "@storybook/theming": 6.4.0-beta.19
+    "@storybook/ui": 6.4.0-beta.19
     "@types/node": ^14.0.10
     "@types/webpack": ^4.41.26
     autoprefixer: ^9.8.6
@@ -2736,47 +2736,47 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: b3772c667e916a810417cdf2dc2a4f88087a4f795a2f41f4a2cefd2886350ed03ff0cfec18fc339518fbc8ed2ea38421d18ac57b4e118e952dae64379beb6a58
+  checksum: d44c03c2b0203f7574c3f8ffc6bbe0c4d1edd461305fbc2803125f29ff227b6168c1b6973f8822a29f1d51abfbfcc09d2781251876388d8614cbecfe1d486e00
   languageName: node
   linkType: hard
 
-"@storybook/channel-postmessage@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/channel-postmessage@npm:6.4.0-beta.14"
+"@storybook/channel-postmessage@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/channel-postmessage@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/channels": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/channels": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     core-js: ^3.8.2
     global: ^4.4.0
     qs: ^6.10.0
     telejson: ^5.3.2
-  checksum: 665dcfa54a217279623666bb39a78108e3c19b228bafd17b9ea2be103aca8b65452466f48a973fac07ec28c935ffb7cc3f42fda1ded708db4615e4db3904f576
+  checksum: 81e2d5b4e32f4c6ecbb8b31e051788779a31d501fe89b74de4bcef23a72186d893bedc0a861c5cc53addb7d996adf1b9774b7a2ae220c260e44934f3916dec39
   languageName: node
   linkType: hard
 
-"@storybook/channels@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/channels@npm:6.4.0-beta.14"
+"@storybook/channels@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/channels@npm:6.4.0-beta.19"
   dependencies:
     core-js: ^3.8.2
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
-  checksum: 48b2610d2324d02778d0010305fa0dd52834bb995c445c95a35fdd10e22465a20b202e6f7da10715e18fb575f4fbc89b7452d802b07271a63aba029f20abb6ef
+  checksum: 05ed0b6199c9546325ba0800e8bef54650548669e11ffc0dc0f948fdbe6287d59d07c7deecb2f412c1612bc0d56359f67fb9e147cc0d85c381cbeffaa098c596
   languageName: node
   linkType: hard
 
-"@storybook/client-api@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/client-api@npm:6.4.0-beta.14"
+"@storybook/client-api@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/client-api@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/channel-postmessage": 6.4.0-beta.14
-    "@storybook/channels": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/channel-postmessage": 6.4.0-beta.19
+    "@storybook/channels": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/store": 6.4.0-beta.14
+    "@storybook/store": 6.4.0-beta.19
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
@@ -2792,28 +2792,28 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 99da4b92dd21b464729c7ff920a775b6923a481d1d7133d8c046da4d7f0d53813521670da1a187a02a4d03fb8e25e1a594290a5bbb5a0f110c7f8e1528fd92d8
+  checksum: 3a312127d877e090545257cf396fb0fd477b3a8861d9e0d27bcb0f9f4d9d2e842cb7cf8fbe669468c6160f889d1bf08c86160f186e50b56e66f27700206e7c84
   languageName: node
   linkType: hard
 
-"@storybook/client-logger@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/client-logger@npm:6.4.0-beta.14"
+"@storybook/client-logger@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/client-logger@npm:6.4.0-beta.19"
   dependencies:
     core-js: ^3.8.2
     global: ^4.4.0
-  checksum: 606f0ae4af1fb297b458a98a531f89d6c15e10a60682c2c0133788be300cb48b191fcf378c0d53f29b686cd97c24b70dae6c2a47e410e017fedc738bb00df5c0
+  checksum: fb9607fcc5c496eef30e9e715da7976a75a9a3cac42bcdc0e3984da1133af9d195dbded2b3c2d8160400bea84be0ba844568582b50a1cb04bb51ca82e1a53978
   languageName: node
   linkType: hard
 
-"@storybook/components@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/components@npm:6.4.0-beta.14"
+"@storybook/components@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/components@npm:6.4.0-beta.19"
   dependencies:
     "@popperjs/core": ^2.6.0
-    "@storybook/client-logger": 6.4.0-beta.14
+    "@storybook/client-logger": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.0-beta.14
+    "@storybook/theming": 6.4.0-beta.19
     "@types/color-convert": ^2.0.0
     "@types/overlayscrollbars": ^1.12.0
     "@types/react-syntax-highlighter": 11.0.5
@@ -2837,23 +2837,23 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 00a912e5489ea02ef7b0baae217220c5a12b5daa319d8c19652541e996924fd82ca5e17cc7b0f2a4eea1e798f41238ce10104fa1512041ad3e5d11fe25f3010f
+  checksum: 27a877314e48d550dae68b51706c40caefd84ae7eb0fa83147f54fb0995d1b2b373f4a6bb69cdae16402870f8ecb72c383f83f4f93fd30cb38008af23fe14c89
   languageName: node
   linkType: hard
 
-"@storybook/core-client@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/core-client@npm:6.4.0-beta.14"
+"@storybook/core-client@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/core-client@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/channel-postmessage": 6.4.0-beta.14
-    "@storybook/client-api": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/channel-postmessage": 6.4.0-beta.19
+    "@storybook/client-api": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/preview-web": 6.4.0-beta.14
-    "@storybook/store": 6.4.0-beta.14
-    "@storybook/ui": 6.4.0-beta.14
+    "@storybook/preview-web": 6.4.0-beta.19
+    "@storybook/store": 6.4.0-beta.19
+    "@storybook/ui": 6.4.0-beta.19
     airbnb-js-shims: ^2.2.1
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
@@ -2871,13 +2871,13 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 1898054c195a5943fbd64ed0a0cd516b3716f494f2355fa138e2d6dc7d31d4b023881fe8958819084ef4ce52f6b623d4a988d41e8593c327e797ac2e4b252bad
+  checksum: 760b918071843640c085721f740936cd7b0f471e4b856f7c67b53e6cd454cbcb51be581483e764ce08c509b6b6d1cc1d2e49ebedadc1be3eaeba29fc75375e11
   languageName: node
   linkType: hard
 
-"@storybook/core-common@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/core-common@npm:6.4.0-beta.14"
+"@storybook/core-common@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/core-common@npm:6.4.0-beta.19"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -2900,7 +2900,7 @@ __metadata:
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
     "@babel/register": ^7.12.1
-    "@storybook/node-logger": 6.4.0-beta.14
+    "@storybook/node-logger": 6.4.0-beta.19
     "@storybook/semver": ^7.3.2
     "@types/micromatch": ^4.0.1
     "@types/node": ^14.0.10
@@ -2925,6 +2925,7 @@ __metadata:
     pretty-hrtime: ^1.0.3
     resolve-from: ^5.0.0
     slash: ^3.0.0
+    telejson: ^5.3.2
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
     webpack: 4
@@ -2934,33 +2935,33 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 0135d67ffc76fd089c82413705dc2290ad8368e9e4d01c756cf5051322953277123fc2bae7be4e446999e7b9d71a0e90f20f8d485341cdceaf450ba1a27c9f5e
+  checksum: dec54bf4c47249fb67116c33f42451ddf6576eaaa25506ff6e289bcd14563eddd4a7380c0653f92106d571bdf28cf1b4a6aa8e51f63825db7c54c6305be16952
   languageName: node
   linkType: hard
 
-"@storybook/core-events@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/core-events@npm:6.4.0-beta.14"
+"@storybook/core-events@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/core-events@npm:6.4.0-beta.19"
   dependencies:
     core-js: ^3.8.2
-  checksum: d9b82c3646b8302c5a67aaf8f50a1bd3a40750e6ac9b748dd1c9426461c326048ad375e4c70fdf8de49bae421727f11399e0ada2b31d2942f2e02d132e4f20dd
+  checksum: 3917b04c8a7e08aec35296d187d4b1ee3f95fc1932f4b39c18eaadc07e9d5d1ff41f5f124f9434f5d9c39c6ddcae9b5e00527548d2b806be9e14e8aa26128421
   languageName: node
   linkType: hard
 
-"@storybook/core-server@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/core-server@npm:6.4.0-beta.14"
+"@storybook/core-server@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/core-server@npm:6.4.0-beta.19"
   dependencies:
     "@discoveryjs/json-ext": ^0.5.3
-    "@storybook/builder-webpack4": 6.4.0-beta.14
-    "@storybook/core-client": 6.4.0-beta.14
-    "@storybook/core-common": 6.4.0-beta.14
+    "@storybook/builder-webpack4": 6.4.0-beta.19
+    "@storybook/core-client": 6.4.0-beta.19
+    "@storybook/core-common": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/csf-tools": 6.4.0-beta.14
-    "@storybook/manager-webpack4": 6.4.0-beta.14
-    "@storybook/node-logger": 6.4.0-beta.14
+    "@storybook/csf-tools": 6.4.0-beta.19
+    "@storybook/manager-webpack4": 6.4.0-beta.19
+    "@storybook/node-logger": 6.4.0-beta.19
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.0-beta.14
+    "@storybook/store": 6.4.0-beta.19
     "@types/node": ^14.0.10
     "@types/node-fetch": ^2.5.7
     "@types/pretty-hrtime": ^1.0.0
@@ -2979,18 +2980,20 @@ __metadata:
     fs-extra: ^9.0.1
     globby: ^11.0.2
     ip: ^1.1.5
+    lodash: ^4.17.20
     node-fetch: ^2.6.1
     pretty-hrtime: ^1.0.3
     prompts: ^2.4.0
     regenerator-runtime: ^0.13.7
     serve-favicon: ^2.5.0
+    slash: ^3.0.0
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
     watchpack: ^2.2.0
     webpack: 4
   peerDependencies:
-    "@storybook/builder-webpack5": 6.4.0-beta.14
-    "@storybook/manager-webpack5": 6.4.0-beta.14
+    "@storybook/builder-webpack5": 6.4.0-beta.19
+    "@storybook/manager-webpack5": 6.4.0-beta.19
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   peerDependenciesMeta:
@@ -3000,18 +3003,18 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 119adfbf893a4e8410a597fa81cebf4483a314b7a9acdfda716ebff50c110b52acf41b8c325cde86f86720cad34badd91bdab3e47d091b3b75f11f9c06ddbd85
+  checksum: 146e4dccee186c4baeeaba27eee01bd3cea52e372f64f31ecced938fb6aeb3927322fa4a0071dc3ac659ee0e7930b81b13d8d9ef4aa1e954ceeee68a443320e9
   languageName: node
   linkType: hard
 
-"@storybook/core@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/core@npm:6.4.0-beta.14"
+"@storybook/core@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/core@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/core-client": 6.4.0-beta.14
-    "@storybook/core-server": 6.4.0-beta.14
+    "@storybook/core-client": 6.4.0-beta.19
+    "@storybook/core-server": 6.4.0-beta.19
   peerDependencies:
-    "@storybook/builder-webpack5": 6.4.0-beta.14
+    "@storybook/builder-webpack5": 6.4.0-beta.19
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
     webpack: "*"
@@ -3020,13 +3023,13 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: b88823f477894175673378c89c7ef1f18a995c2262f4b53881787de6e2e77c5f99f826f89623d7afa436d52a10f7a6ec1f93885fc85a00de19f846fc21742b5f
+  checksum: 79de53d054b66a670eb8afaa9c5eb496577adcf40a49c14a4e69626fa8fde717cdb34191d43b1217032f9354b675591ecf1099c5becb3562a44589b0ee279185
   languageName: node
   linkType: hard
 
-"@storybook/csf-tools@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/csf-tools@npm:6.4.0-beta.14"
+"@storybook/csf-tools@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/csf-tools@npm:6.4.0-beta.19"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/generator": ^7.12.11
@@ -3045,7 +3048,7 @@ __metadata:
     prettier: ^2.2.1
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
-  checksum: 92179f3602d4e41c4859389762258bf43f7b004ce90dec4ab73673d329e9461944d4406f64a6a72426946312eaf06f15b51433789fe22e2790c301ac39d27ea1
+  checksum: f124214e57eb54f81b95f01211169902bc6c3c17cdb5ee89645f68e716994fe987709ab38fa8114aafe60e6ab8fb42770f33a139e480b01119743e2d21a4ed48
   languageName: node
   linkType: hard
 
@@ -3089,19 +3092,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/manager-webpack4@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/manager-webpack4@npm:6.4.0-beta.14"
+"@storybook/manager-webpack4@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/manager-webpack4@npm:6.4.0-beta.19"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-template-literals": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/core-client": 6.4.0-beta.14
-    "@storybook/core-common": 6.4.0-beta.14
-    "@storybook/node-logger": 6.4.0-beta.14
-    "@storybook/theming": 6.4.0-beta.14
-    "@storybook/ui": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/core-client": 6.4.0-beta.19
+    "@storybook/core-common": 6.4.0-beta.19
+    "@storybook/node-logger": 6.4.0-beta.19
+    "@storybook/theming": 6.4.0-beta.19
+    "@storybook/ui": 6.4.0-beta.19
     "@types/node": ^14.0.10
     "@types/webpack": ^4.41.26
     babel-loader: ^8.0.0
@@ -3135,42 +3138,42 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: dd6a10fb826f5fb3f6324ed4994e0ba46648329824616ef0ceb9f5eff8c0b52bbe8916c71cf306a3441abbbb324fe0fd0127b18c3b3a137f234fe71c1734a4e6
+  checksum: db14b5671c61f702f6c7870918103e26d44f5b4bed6b65c873afaad7c6c7198e1cdac91e95c513cbcf9d54369a878fea489c42bf2bcf25f7e1ba5fb646da735e
   languageName: node
   linkType: hard
 
-"@storybook/node-logger@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/node-logger@npm:6.4.0-beta.14"
+"@storybook/node-logger@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/node-logger@npm:6.4.0-beta.19"
   dependencies:
     "@types/npmlog": ^4.1.2
     chalk: ^4.1.0
     core-js: ^3.8.2
     npmlog: ^5.0.1
     pretty-hrtime: ^1.0.3
-  checksum: 106429e0764a6a90e8e082e09f80c19a8623c0b67ddf7c4dbc7e590f7386c34ca8ef4d284c9590f833c273f49001361be9424900115f59c94f445243ef9651e7
+  checksum: 4b914a36556a647709e0c5fc9b9b77135662b8e6639656f7efd35be1ef8b7866f914503ebb232320c236e6879ae67905e42080febee5755473df71a909501319
   languageName: node
   linkType: hard
 
-"@storybook/postinstall@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/postinstall@npm:6.4.0-beta.14"
+"@storybook/postinstall@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/postinstall@npm:6.4.0-beta.19"
   dependencies:
     core-js: ^3.8.2
-  checksum: 2c1fd249a46c925ecb80d71c9ccc2377ccc817864886d85cb0c5d2585ac47695f5e2ec874d410f05f1d868600c0ba0cc1626d7b3323940e4c56d41181e92f925
+  checksum: 615054f8d54880464f9b5d228f25d9710dab11d2cfcf816a251a02ef859ca4c9ec2fb52a36be33ecd1f69f5286ce9a8061603a387a34a3e2927f080c57ee25dc
   languageName: node
   linkType: hard
 
-"@storybook/preview-web@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/preview-web@npm:6.4.0-beta.14"
+"@storybook/preview-web@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/preview-web@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/channel-postmessage": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/channel-postmessage": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/store": 6.4.0-beta.14
+    "@storybook/store": 6.4.0-beta.19
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
     global: ^4.4.0
@@ -3183,7 +3186,7 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: c64264ad517c0ea79756416008c0897c4b50d4af52786a47df061e01ce21eac9518a5b159f07d5ddd3817b618df66a2fdc32a39f0c8610e2a12dcdb522dfba8d
+  checksum: 9694018926c27edbb4871a413fe921917763b19a54db5960b9bc9d063f3b9712d11b67be100ba9cb29c597e10b6c38f45758785225e07cb4ea1271ebf0009b44
   languageName: node
   linkType: hard
 
@@ -3205,21 +3208,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react@npm:^6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/react@npm:6.4.0-beta.14"
+"@storybook/react@npm:^6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/react@npm:6.4.0-beta.19"
   dependencies:
     "@babel/preset-flow": ^7.12.1
     "@babel/preset-react": ^7.12.10
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.1
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/core": 6.4.0-beta.14
-    "@storybook/core-common": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/core": 6.4.0-beta.19
+    "@storybook/core-common": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/node-logger": 6.4.0-beta.14
+    "@storybook/node-logger": 6.4.0-beta.19
     "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.253f8c1.0
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.0-beta.14
+    "@storybook/store": 6.4.0-beta.19
     "@types/webpack-env": ^1.16.0
     babel-plugin-add-react-displayname: ^0.0.5
     babel-plugin-named-asset-import: ^0.3.1
@@ -3247,16 +3250,16 @@ __metadata:
     build-storybook: bin/build.js
     start-storybook: bin/index.js
     storybook-server: bin/index.js
-  checksum: 529bdc8b761bf9fca18ba8adc512c9574824bfa5149248dd0fd16edd6f17ad1d23a05e36c0e65b7a8e511e1c1c66f755b74c9e9a13c2d9d14a8e0720b81ff3cb
+  checksum: 5695dd8bb948a65ea8b053c1f0fad1b37e51e5d8522b9c0d7b570173024f3b6fa0403928bcff7e62afaebc848ec7da7a32dde160de89ade6472602c2ce9d2cf0
   languageName: node
   linkType: hard
 
-"@storybook/router@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/router@npm:6.4.0-beta.14"
+"@storybook/router@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/router@npm:6.4.0-beta.19"
   dependencies:
     "@reach/router": ^1.3.4
-    "@storybook/client-logger": 6.4.0-beta.14
+    "@storybook/client-logger": 6.4.0-beta.19
     "@types/reach__router": ^1.3.7
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
@@ -3268,7 +3271,7 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 661b2e335a708e186e5e63b3191e1ab2d4c47d12ad12491dea1df8e3218a7fd825c8b874b526a977f76f6498777ebf599c315c718a6e86d098cd2f46337861ad
+  checksum: 468b2af932217ddbd44e304a29d70361791240ae446153f2f9fb5e193d03e51d36866f5c3ac20b9d0cfabb881ccf132f1b1eb89d274cbfce249026de8de1b1f8
   languageName: node
   linkType: hard
 
@@ -3284,12 +3287,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/source-loader@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/source-loader@npm:6.4.0-beta.14"
+"@storybook/source-loader@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/source-loader@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
     core-js: ^3.8.2
     estraverse: ^5.2.0
@@ -3301,17 +3304,17 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: ce1a531fc6e5de3ea6985560bcf265e9c5fb066e501768903b8f9958168862f8961d7daa4d23b5f67de962b9cdd8e78ec7ae7009275d5a2841d92874045dfd25
+  checksum: 7e676b93b4e51e923895a5d7b7a0453c469152552260a6e73d13ff669c00404b5b06177667c08f88545e0a1e60f6629d9f2635d89599d4ca26e94bb8342f44ab
   languageName: node
   linkType: hard
 
-"@storybook/store@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/store@npm:6.4.0-beta.14"
+"@storybook/store@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/store@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
@@ -3323,19 +3326,19 @@ __metadata:
     stable: ^0.1.8
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
-  checksum: 5c0e89f3956c4e30cd6bbf52f16abbee2b7ce0e26455d6ef1823cc93ff209fe265b8dd3157987cd287395061877c9161969a1ebd8ca5c9b7f9033abe9917cf12
+  checksum: c3eb36e230bde443f4899c0c943be0ef3d1b3d9d0e43fb11e7b9a4d74f2b20c9f067584c53b1e76b41c86a7198afcd96a81df47e70b2f41a120e812af0dd27b9
   languageName: node
   linkType: hard
 
-"@storybook/svelte@npm:^6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/svelte@npm:6.4.0-beta.14"
+"@storybook/svelte@npm:^6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/svelte@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/core": 6.4.0-beta.14
-    "@storybook/core-common": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/core": 6.4.0-beta.19
+    "@storybook/core-common": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/store": 6.4.0-beta.14
+    "@storybook/store": 6.4.0-beta.19
     core-js: ^3.8.2
     global: ^4.4.0
     react: 16.14.0
@@ -3352,18 +3355,18 @@ __metadata:
     build-storybook: bin/build.js
     start-storybook: bin/index.js
     storybook-server: bin/index.js
-  checksum: 90ee641a860f32ae5258b0392f5e0c8b94597d365cfcd502e3745ca70661459e0ee83bf0a5467c38e809b117dafbb6ac3397f4041a3a4a4ccff8d2f3b5dda322
+  checksum: 961b42c9769b1d5f5d5c701556568b19bd4a743108925dfd9e5da50e72b93933e32018c06b53dbdbd01091ba5771f4603b6f04ab897b55c96ab18a212f61e8cb
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/theming@npm:6.4.0-beta.14"
+"@storybook/theming@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/theming@npm:6.4.0-beta.19"
   dependencies:
     "@emotion/core": ^10.1.1
     "@emotion/is-prop-valid": ^0.8.6
     "@emotion/styled": ^10.0.27
-    "@storybook/client-logger": 6.4.0-beta.14
+    "@storybook/client-logger": 6.4.0-beta.19
     core-js: ^3.8.2
     deep-object-diff: ^1.1.0
     emotion-theming: ^10.0.27
@@ -3375,24 +3378,24 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 200d00fb80e3296945ec53f3e380b537be770e6f095da2e868ec10f5cec159b6f548841d26e2bd0638e9b929eccb9378d7d92283eabf2df9661a83560168863a
+  checksum: c9657bed6b286cee1b4e4d70bb329f7c64f6d707f2aa9d1a9b05b89521e28cae0942f47ab118a7a23a98414de5d32ffdb8644d928bd4377ceaa541554e72e6d9
   languageName: node
   linkType: hard
 
-"@storybook/ui@npm:6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/ui@npm:6.4.0-beta.14"
+"@storybook/ui@npm:6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/ui@npm:6.4.0-beta.19"
   dependencies:
     "@emotion/core": ^10.1.1
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/api": 6.4.0-beta.14
-    "@storybook/channels": 6.4.0-beta.14
-    "@storybook/client-logger": 6.4.0-beta.14
-    "@storybook/components": 6.4.0-beta.14
-    "@storybook/core-events": 6.4.0-beta.14
-    "@storybook/router": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/api": 6.4.0-beta.19
+    "@storybook/channels": 6.4.0-beta.19
+    "@storybook/client-logger": 6.4.0-beta.19
+    "@storybook/components": 6.4.0-beta.19
+    "@storybook/core-events": 6.4.0-beta.19
+    "@storybook/router": 6.4.0-beta.19
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.4.0-beta.14
+    "@storybook/theming": 6.4.0-beta.19
     copy-to-clipboard: ^3.3.1
     core-js: ^3.8.2
     core-js-pure: ^3.8.2
@@ -3414,19 +3417,19 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: cd80aa73b971552f25098f18bdc381f60ad1600331b4b64263e1d6346c2ce90ebeeade152825970bc77a58d9663fb58701c6188ecf56a89856952125a002dcd5
+  checksum: f21d94e4b54f45e629b9d6eac7a27ea7975f4cc861b06a64ae82d170715d595513a6bc578d61537bc03223a0695cb62dc7d8b9740265d03099345ab9bf872ae7
   languageName: node
   linkType: hard
 
-"@storybook/vue3@npm:^6.4.0-beta.14":
-  version: 6.4.0-beta.14
-  resolution: "@storybook/vue3@npm:6.4.0-beta.14"
+"@storybook/vue3@npm:^6.4.0-beta.19":
+  version: 6.4.0-beta.19
+  resolution: "@storybook/vue3@npm:6.4.0-beta.19"
   dependencies:
-    "@storybook/addons": 6.4.0-beta.14
-    "@storybook/core": 6.4.0-beta.14
-    "@storybook/core-common": 6.4.0-beta.14
+    "@storybook/addons": 6.4.0-beta.19
+    "@storybook/core": 6.4.0-beta.19
+    "@storybook/core-common": 6.4.0-beta.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/store": 6.4.0-beta.14
+    "@storybook/store": 6.4.0-beta.19
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -3449,7 +3452,7 @@ __metadata:
     build-storybook: bin/build.js
     start-storybook: bin/index.js
     storybook-server: bin/index.js
-  checksum: 4dea36908d2d275c3f8f9f926a0fc0caff7f01d74cf8bdd8435c3d5862a4e142df4841fe7b4a990abe8099a1ea27f7cdf9ce1c10e942380bac169802922c4a82
+  checksum: e4abbac51b3497a433038dca6af67167ec9a1e863db84e1ce78e42decd44894e9657d9c8353baf75a01ee13ae7e55469b26ce9c0d11f0ca669351d27f6b9e25b
   languageName: node
   linkType: hard
 
@@ -7062,10 +7065,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-react@workspace:packages/example-react"
   dependencies:
-    "@storybook/addon-a11y": ^6.4.0-beta.14
-    "@storybook/addon-docs": ^6.4.0-beta.14
-    "@storybook/addon-essentials": ^6.4.0-beta.14
-    "@storybook/react": ^6.4.0-beta.14
+    "@storybook/addon-a11y": ^6.4.0-beta.19
+    "@storybook/addon-docs": ^6.4.0-beta.19
+    "@storybook/addon-essentials": ^6.4.0-beta.19
+    "@storybook/react": ^6.4.0-beta.19
     react: 17.0.2
     react-dom: 17.0.2
     storybook-builder-vite: "workspace:*"
@@ -7077,11 +7080,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-svelte@workspace:packages/example-svelte"
   dependencies:
-    "@storybook/addon-actions": ^6.4.0-beta.14
-    "@storybook/addon-essentials": ^6.4.0-beta.14
-    "@storybook/addon-links": ^6.4.0-beta.14
+    "@storybook/addon-actions": ^6.4.0-beta.19
+    "@storybook/addon-essentials": ^6.4.0-beta.19
+    "@storybook/addon-links": ^6.4.0-beta.19
     "@storybook/addon-svelte-csf": ^1.1.0
-    "@storybook/svelte": ^6.4.0-beta.14
+    "@storybook/svelte": ^6.4.0-beta.19
     "@sveltejs/vite-plugin-svelte": ^1.0.0-next.11
     storybook-builder-vite: "workspace:*"
     svelte: ^3.38.3
@@ -7093,9 +7096,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-vue@workspace:packages/example-vue"
   dependencies:
-    "@storybook/addon-a11y": ^6.4.0-beta.14
-    "@storybook/addon-essentials": ^6.4.0-beta.14
-    "@storybook/vue3": ^6.4.0-beta.14
+    "@storybook/addon-a11y": ^6.4.0-beta.19
+    "@storybook/addon-essentials": ^6.4.0-beta.19
+    "@storybook/vue3": ^6.4.0-beta.19
     "@vitejs/plugin-vue": ^1.2.4
     storybook-builder-vite: "workspace:*"
     vite: ^2.4.1
@@ -9031,10 +9034,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-plain-object@npm:3.0.1":
-  version: 3.0.1
-  resolution: "is-plain-object@npm:3.0.1"
-  checksum: 53b6f5b558a494f20304aad4d484739c96826c4a7c89ef9c6479009df89e725d5a355f592ccba2cd9e94c36fda35d2d229d597f5ccd0c9deb8c8ccd0077ec617
+"is-plain-object@npm:5.0.0":
+  version: 5.0.0
+  resolution: "is-plain-object@npm:5.0.0"
+  checksum: 92bd87f095036fb6ef21fcba4e66734bba1457fc4abece5873bd1fba130c44fa8a4df64a2ef7841da638680af18e1ad2e5fac1095bed3578d0da0afc1f04bcf3
   languageName: node
   linkType: hard
 
@@ -11928,16 +11931,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-element-to-jsx-string@npm:^14.3.2":
-  version: 14.3.2
-  resolution: "react-element-to-jsx-string@npm:14.3.2"
+"react-element-to-jsx-string@npm:^14.3.4":
+  version: 14.3.4
+  resolution: "react-element-to-jsx-string@npm:14.3.4"
   dependencies:
-    "@base2/pretty-print-object": 1.0.0
-    is-plain-object: 3.0.1
+    "@base2/pretty-print-object": 1.0.1
+    is-plain-object: 5.0.0
+    react-is: 17.0.2
   peerDependencies:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
-  checksum: 38e9e094ff98f2d68a37b53524a64047848a42f4f552a4399b39473f75ca62ff88e92b5cf6c8f9bf8be6368407284119b8f31a3a97bb9b793a457bccb8c4fa6c
+  checksum: 16768270ff1045bec3a909144f13cb9e823f6dd19a8ebf3cd999d696d7a84a9a28f638c1ec51d13207567e08c5783345f3c451e817064e778a8f671d80074e1e
   languageName: node
   linkType: hard
 
@@ -11984,17 +11988,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"react-is@npm:17.0.2, react-is@npm:^17.0.2":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 3eff23f410d40ab9bc5177f147a92c7f42c356a21ecea340e0554566956d67e5e1ba56f26cc7fa22339ac3c7151744177bd6305eaa26d3cbf15f354358c9d9b6
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.7.0, react-is@npm:^16.8.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 11bcf1267a314a522615f626f3ce3727a3a24cdbf61c4d452add3550a7875326669631326cfb1ba3e92b6f72244c32ffecf93ad21c0cad8455d3e169d0e3f060
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "react-is@npm:17.0.2"
-  checksum: 3eff23f410d40ab9bc5177f147a92c7f42c356a21ecea340e0554566956d67e5e1ba56f26cc7fa22339ac3c7151744177bd6305eaa26d3cbf15f354358c9d9b6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This updates our examples to use storybook 6.4.0-beta.14.  

One regression I've noticed so far is that the stories are no longer sorted by the export order, but rather alphabetically.  I haven't traced that down to a particular storybook version yet though.

This also uses yarn's `workspace:` protocol so we don't need to update them every time we bump the version of the builder. (https://yarnpkg.com/features/workspaces#publishing-workspaces)