### PR TITLE
Ensure preview or config file is loaded last

### DIFF
--- a/packages/storybook-builder-vite/codegen-iframe-script.js
+++ b/packages/storybook-builder-vite/codegen-iframe-script.js
@@ -22,9 +22,12 @@ module.exports.generateIframeScriptCode =
         // is loaded. That way our client-apis can assume the existence of the API+store
         const frameworkImportPath = frameworkPath || `@storybook/${framework}`;
 
-        const configEntries = [loadPreviewOrConfigFile({ configDir })]
-            .concat(await presets.apply('config', [], options))
-            .filter(Boolean);
+        const previewOrConfigFile = loadPreviewOrConfigFile({ configDir });
+        const presetEntries = await presets.apply('config', [], options);
+        const configEntries = [previewOrConfigFile, ...presetEntries].filter(
+            Boolean
+        );
+
         const storyEntries = (
             await Promise.all(
                 (


### PR DESCRIPTION
Add-on defaults currently overwrite configuration from `preview.js`. This moves preview to the end of the preset list.

Fixes #62 and might fix some others as well