### PR TITLE
Don't generate source maps for MDX files

### DIFF
--- a/packages/storybook-builder-vite/source-loader-plugin.js
+++ b/packages/storybook-builder-vite/source-loader-plugin.js
@@ -17,7 +17,10 @@ module.exports.sourceLoaderPlugin = function () {
                     var __LOCATIONS_MAP__ = ${JSON.stringify(addsMap)};
                 `;
 
-                return `${preamble}\n${source}`;
+                return {
+                    code: `${preamble}\n${source}`,
+                    map: { mappings: '' },
+                };
             }
         },
     };


### PR DESCRIPTION
Not sure if there's any point to generating source-maps for MDX files so I've followed the instructions here to skip generating source maps for MDX files:

https://rollupjs.org/guide/en/#source-code-transformations

Closes #150