### PR TITLE
Explore adding react-docgen

### DIFF
--- a/packages/storybook-builder-vite/package.json
+++ b/packages/storybook-builder-vite/package.json
@@ -17,6 +17,7 @@
         "@storybook/csf-tools": "^6.3.3",
         "@storybook/source-loader": "^6.3.12",
         "@vitejs/plugin-react": "^1.0.8",
+        "babel-plugin-react-docgen": "^4.2.1",
         "es-module-lexer": "^0.9.3",
         "glob": "^7.2.0",
         "glob-promise": "^4.2.0",

--- a/packages/storybook-builder-vite/vite-config.js
+++ b/packages/storybook-builder-vite/vite-config.js
@@ -58,10 +58,18 @@ module.exports.pluginConfig = function pluginConfig(options, type) {
             require('@vitejs/plugin-react')({
                 // Do not treat story files as HMR boundaries, storybook itself needs to handle them.
                 exclude: [/\.stories\.(t|j)sx?$/, /node_modules/],
+                babel: {
+                    plugins: [[
+                        require.resolve('babel-plugin-react-docgen'),
+                        {
+                            DOC_GEN_COLLECTION_NAME: 'STORYBOOK_REACT_CLASSES',
+                        },
+                    ]]
+                }
             })
         );
     }
-    
+
     if (framework === 'glimmerx') {
         const plugin = require('vite-plugin-glimmerx/index.cjs');
         plugins.push(plugin.default());

--- a/yarn.lock
+++ b/yarn.lock
@@ -13618,6 +13618,7 @@ fsevents@^1.2.7:
     "@storybook/csf-tools": ^6.3.3
     "@storybook/source-loader": ^6.3.12
     "@vitejs/plugin-react": ^1.0.8
+    babel-plugin-react-docgen: ^4.2.1
     es-module-lexer: ^0.9.3
     glob: ^7.2.0
     glob-promise: ^4.2.0


### PR DESCRIPTION
I know there's some work going on in storybook core (https://github.com/eirslett/storybook-builder-vite/issues/2#issuecomment-823064989) as @shilman mentioned, but I've managed to get react-docgen working (I haven't really tested it's performance) but it might be worth exploring adding this temporarily so the feature works?