### PR TITLE
Fix builder for vite 2.7.0

### DIFF
--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -20,6 +20,6 @@
         "@storybook/addon-essentials": "^6.4.0",
         "@storybook/react": "^6.4.0",
         "storybook-builder-vite": "workspace:*",
-        "vite": "^2.4.1"
+        "vite": "2.7.0-beta.4"
     }
 }

--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -20,6 +20,6 @@
         "@storybook/addon-essentials": "^6.4.0",
         "@storybook/react": "^6.4.0",
         "storybook-builder-vite": "workspace:*",
-        "vite": "2.7.0-beta.4"
+        "vite": "2.7.0"
     }
 }

--- a/packages/example-svelte/package.json
+++ b/packages/example-svelte/package.json
@@ -21,6 +21,6 @@
         "@storybook/svelte": "^6.4.0",
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",
         "storybook-builder-vite": "workspace:*",
-        "vite": "2.7.0-beta.4"
+        "vite": "2.7.0"
     }
 }

--- a/packages/example-svelte/package.json
+++ b/packages/example-svelte/package.json
@@ -21,6 +21,6 @@
         "@storybook/svelte": "^6.4.0",
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",
         "storybook-builder-vite": "workspace:*",
-        "vite": "^2.4.1"
+        "vite": "2.7.0-beta.4"
     }
 }

--- a/packages/example-vue/package.json
+++ b/packages/example-vue/package.json
@@ -19,6 +19,6 @@
         "@storybook/vue3": "^6.4.0",
         "@vitejs/plugin-vue": "^1.2.4",
         "storybook-builder-vite": "workspace:*",
-        "vite": "^2.4.1"
+        "vite": "2.7.0-beta.4"
     }
 }

--- a/packages/example-vue/package.json
+++ b/packages/example-vue/package.json
@@ -19,6 +19,6 @@
         "@storybook/vue3": "^6.4.0",
         "@vitejs/plugin-vue": "^1.2.4",
         "storybook-builder-vite": "workspace:*",
-        "vite": "2.7.0-beta.4"
+        "vite": "2.7.0"
     }
 }

--- a/packages/storybook-builder-vite/code-generator-plugin.js
+++ b/packages/storybook-builder-vite/code-generator-plugin.js
@@ -8,7 +8,9 @@ const { generateImportFnScriptCode } = require('./codegen-importfn-script');
 module.exports.codeGeneratorPlugin = function codeGeneratorPlugin(options) {
     const virtualFileId = '/virtual:/@storybook/builder-vite/vite-app.js';
     const virtualStoriesFile = '/virtual:/@storybook/builder-vite/storybook-stories.js';
+    const iframePath = path.resolve(__dirname, 'input', 'iframe.html');
     let iframeId;
+
     return {
         name: 'storybook-vite-code-generator-plugin',
         enforce: 'pre',
@@ -22,7 +24,7 @@ module.exports.codeGeneratorPlugin = function codeGeneratorPlugin(options) {
                     server.moduleGraph.invalidateModule(appModule);
                 }
                 const storiesModule = moduleGraph.getModuleById(virtualStoriesFile);
-                if(storiesModule) {
+                if (storiesModule) {
                     server.moduleGraph.invalidateModule(storiesModule);
                 }
             });
@@ -34,7 +36,7 @@ module.exports.codeGeneratorPlugin = function codeGeneratorPlugin(options) {
             // does not support virtual files as entry points.
             if (command === 'build') {
                 config.build.rollupOptions = {
-                    input: 'iframe.html',
+                    input: iframePath,
                 };
             }
         },
@@ -44,7 +46,7 @@ module.exports.codeGeneratorPlugin = function codeGeneratorPlugin(options) {
         resolveId(source) {
             if (source === virtualFileId) {
                 return virtualFileId;
-            } else if (source === 'iframe.html') {
+            } else if (source === iframePath) {
                 return iframeId;
             } else if (source === virtualStoriesFile) {
                 return virtualStoriesFile;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7394,7 +7394,7 @@ __metadata:
     react: 17.0.2
     react-dom: 17.0.2
     storybook-builder-vite: "workspace:*"
-    vite: 2.7.0-beta.4
+    vite: 2.7.0
   languageName: unknown
   linkType: soft
 
@@ -7410,7 +7410,7 @@ __metadata:
     "@sveltejs/vite-plugin-svelte": ^1.0.0-next.11
     storybook-builder-vite: "workspace:*"
     svelte: ^3.38.3
-    vite: 2.7.0-beta.4
+    vite: 2.7.0
   languageName: unknown
   linkType: soft
 
@@ -7423,7 +7423,7 @@ __metadata:
     "@storybook/vue3": ^6.4.0
     "@vitejs/plugin-vue": ^1.2.4
     storybook-builder-vite: "workspace:*"
-    vite: 2.7.0-beta.4
+    vite: 2.7.0
     vue: ^3.1.4
   languageName: unknown
   linkType: soft
@@ -14844,9 +14844,9 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"vite@npm:2.7.0-beta.4":
-  version: 2.7.0-beta.4
-  resolution: "vite@npm:2.7.0-beta.4"
+"vite@npm:2.7.0":
+  version: 2.7.0
+  resolution: "vite@npm:2.7.0"
   dependencies:
     esbuild: ^0.13.12
     fsevents: ~2.3.2
@@ -14869,7 +14869,7 @@ fsevents@^1.2.7:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: f5a3ebeda3ac58d328936d678d283264f680befac2b092bccccbdc913be5f28cb27ad9e60c6f54ac2edd6abc973f753a7a4260690984680007a38db78a0f202d
+  checksum: 616af241a9d45adc489db2b276be62ec24b6d6c19a3ac0c16546152b3e26d4230bf0b849cc1d0cc01f4f39591050a2531580caa41e5cc793c8238a2fd0bf2757
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6950,146 +6950,146 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-android-arm64@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-android-arm64@npm:0.13.13"
-  checksum: 53349efc7b1145bf65bfdc9ae25b2a5908a850562a4db3b8e9e265fe021071df4e5d645341d276474f597ff983c2da23c8e8676a96fe64b03e0939d9eb580559
+"esbuild-android-arm64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-android-arm64@npm:0.13.15"
+  checksum: e9e40c7d5da9725e6ce24a8e05d904f7fc0bcf09a5d24d2344414d19805aa8b18e8251ed48f01c3c8a83a99bd54e6c2650c9e33939e4e5026c4bd503a4be2bae
   languageName: node
   linkType: hard
 
-"esbuild-darwin-64@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-darwin-64@npm:0.13.13"
-  checksum: a371aa7718c686b89589e6ac3efc0b094f016432187f3f6b8ac68ec1fe2e19674832f93c16d8565b6bc5a83d703a9df5c57510285e038700d458bdfdd2c9d458
+"esbuild-darwin-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-darwin-64@npm:0.13.15"
+  checksum: 0ce6c78a14a310df3dbff43935b5c6d5dc64036eba3719834ea3dbbbb3fd6e4821687cae18e7763c9bb3dc9a32fad2381260c10e61fe1af7fe5771944ff09435
   languageName: node
   linkType: hard
 
-"esbuild-darwin-arm64@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-darwin-arm64@npm:0.13.13"
-  checksum: 8e264a5073d02a94f4da14f52ef90768a2739cb8211679b518f8e4ef5f4907e85d31ab21d3bdd30c407326fcbd09cce2c9206c41a4359854fadc2f2cf8f4ba7c
+"esbuild-darwin-arm64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-darwin-arm64@npm:0.13.15"
+  checksum: 87cd57fb5bae544f3c533fa50634f7704f24b62334472482a83416009aabc09b70215f5abfdd40de8f447f126c8725f735c73e92f178bfe868197ee257615d48
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-64@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-freebsd-64@npm:0.13.13"
-  checksum: 57e85c449588255510b3e9a89a94bbf5a4b4c5d7051d703763401ac2a5ed643456353334bf05779d4a0d5ef59b30f2766924df9c61947dc9d8c434821514ca48
+"esbuild-freebsd-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-freebsd-64@npm:0.13.15"
+  checksum: 1d79ca59d5ee937b11840a78852374c731540dd45376920416f0a1ed623ed90d61482ba91d0c2d77cf95a0250cd50aee13163320e52c67c565564aa6dea316d3
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-arm64@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-freebsd-arm64@npm:0.13.13"
-  checksum: 1ce1d172e1a0299b033ea8f33ac4f816ccdc3b430e86f1d33ee95f49b2e4e2b3179972dd91a71e82c74b85a95d28bfb98ec96b8ce9029fd28ce6ecafbc78b5ff
+"esbuild-freebsd-arm64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-freebsd-arm64@npm:0.13.15"
+  checksum: 9960cbc1d275c614be204a92aedbc912bc8bb449499675c02851fcefd94872e35ebb7e066f6b01a63f31f1a4201e435b5d04fca5d1799f4363c6cbc67cc8aff5
   languageName: node
   linkType: hard
 
-"esbuild-linux-32@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-linux-32@npm:0.13.13"
-  checksum: d21f2537444b8b70c85d2606e61afba155d44fe008d2426a6c58e39f2e95095bdffe3d428850ab537eacc588426ef915a21f91fffe960eac3014cd496d835ab5
+"esbuild-linux-32@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-linux-32@npm:0.13.15"
+  checksum: a6ab52bd5ac3ea00c5d0d032cc9b4dceaa19509bfb2e445da6be6287cb61a4182d0f8e24b555952feeab353c9e24873fe71a602f0b0cdb36bbcf79b6a976f1b6
   languageName: node
   linkType: hard
 
-"esbuild-linux-64@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-linux-64@npm:0.13.13"
-  checksum: ae213734a847ec0343f1a87daebb87b2c8a2b223c562a7fb409e24d92ddbc65464d4d8e81415f4a7f6fa20b9dd030b013b1120ac7c33c8d8a7f96ba2a4b6d09a
+"esbuild-linux-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-linux-64@npm:0.13.15"
+  checksum: 9dab3d103858db0ffd186b07b0af38be8738149701064a39664224cfec4d8798621f5a64c90069c45a011df7ba58abd0440b2538089e7bb0d3e799ce5d4af7a2
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm64@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-linux-arm64@npm:0.13.13"
-  checksum: 088c8b256778c779a0886ae3fea78befd11b7cd60542d6592266de90af912dd479d95d2d49106b992b92bfc92bfca1870f0e5fff6e84d4a6346be5434735585e
+"esbuild-linux-arm64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-linux-arm64@npm:0.13.15"
+  checksum: 2f8dc3e26d1a99f757c67f5c7d115c0f4bd9c7c6ca16716ca04a887c075742db7795e99a0a4a518ff54b5fadf92caa77f1e712fe6821101321ba608cab200ef5
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-linux-arm@npm:0.13.13"
-  checksum: 7045b0bd902b68507384e43f8fe571f3f62068cc0c7e699645d64cb43abbf26df454146bac1f03b6f2fd30a96399fc0870074e8cc47737ef13302a22aa2f8603
+"esbuild-linux-arm@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-linux-arm@npm:0.13.15"
+  checksum: 5907987eb043441db2856c4fdfd37f788cbbbb6b3f5587628ef7822d590a6ce637ad1439f35e8293f2d27d3f1368a370f782188fa0d0ae2089611bbd3c2c3764
   languageName: node
   linkType: hard
 
-"esbuild-linux-mips64le@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-linux-mips64le@npm:0.13.13"
-  checksum: b8d026a749631b2a276318ff06e753520b3b7aec144f08ade0e20ba4de4d059abc2f17d2705a9f440239c1573c19e255b6d508b1c02c75ba983733d3c4343a85
+"esbuild-linux-mips64le@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-linux-mips64le@npm:0.13.15"
+  checksum: 04eb2094630ba1871ce2b0cdd6a5c39797672030325735a284bf36e6fa9e9e50885637e1a3c5db90f411caebfc854d8c8dc064d3bb1753a68d2f8d9925e5373a
   languageName: node
   linkType: hard
 
-"esbuild-linux-ppc64le@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-linux-ppc64le@npm:0.13.13"
-  checksum: 9261d2e12541ec79319e0ac42aec347942c53f84358db9e216e215c9d7eddd1e8da3518d5ae58042ae26f3c8e0b44f631825426cd919db3ff1b637f6bbdfa493
+"esbuild-linux-ppc64le@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-linux-ppc64le@npm:0.13.15"
+  checksum: 379728ff5dd93577e4ade98ea0384876450ab0c4fd75bda404a27cac6410d0ed727a3f9bc8442c222c248ebc2c26a0f7438e4ceaa893e5912de8fa28cc198260
   languageName: node
   linkType: hard
 
-"esbuild-netbsd-64@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-netbsd-64@npm:0.13.13"
-  checksum: 13bccdcd4072cc5e7a4ec2de05708b7b5148ec29f1dac1c8d8a83b95f2d3e46cc1720605116129d0e2d924155f600b2e8d7188b6a8c360d8176ca5aa14eb5310
+"esbuild-netbsd-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-netbsd-64@npm:0.13.15"
+  checksum: b7e714fc0403479eb04579104a9ca54654f67bf6e8b63e2937bc4e981eaadc6e6dfaa09b1b4034a360d30179ed64dfabd8cefe0205d1da4fd102e43c849a2e18
   languageName: node
   linkType: hard
 
-"esbuild-openbsd-64@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-openbsd-64@npm:0.13.13"
-  checksum: 35259bc22ea13c67f1f09c5ca74295fdf0a59a3816cdc4fcb57b32193e3e51df0094dc0e4e9f8bb8ad678f2892a1b0ab0016bc764f28c1c621cc0bc6a265b95e
+"esbuild-openbsd-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-openbsd-64@npm:0.13.15"
+  checksum: 88bbeb1c1f6a5b2c08a69a0ca7db2021f64ed62207db74ca173a3e7a7f9dd0a082ce9667294ea85190b4e86a0cf70a9de91d9b659f9e94afc6881dbb68868ae0
   languageName: node
   linkType: hard
 
-"esbuild-sunos-64@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-sunos-64@npm:0.13.13"
-  checksum: a86a356c28fffb36d80a12a03b5af2a7d77f6389ba26a10d98db945912d15d09d03efae60cbaed3fc95b8b19de5f36c73343d19065a781cdb790b716f6a7340a
+"esbuild-sunos-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-sunos-64@npm:0.13.15"
+  checksum: c5e6825af7c979906a344fdab7d3f0d9e7d6b17e76e1f50fb0286f3480dd65e2ce45bcf07debff3646f7632affe628733d95cc4252dcade6fce7b843116b0138
   languageName: node
   linkType: hard
 
-"esbuild-windows-32@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-windows-32@npm:0.13.13"
-  checksum: 2b73f2709e590208abc437e842085ba42d5ba39d6a9bc10280b8c193206f7f0cc764d6c762fa11f234a038deacbfa6ac38f9f8fe949e3a80ae34a6feec184118
+"esbuild-windows-32@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-windows-32@npm:0.13.15"
+  checksum: ea2e3c60b7ddda438329323bc9df8666e7280648fb1f5c6bd332a76013a923f058a685d1a5c3f5e196940654cc304f9c71ed8ef80575cd89dd85f37fc8064066
   languageName: node
   linkType: hard
 
-"esbuild-windows-64@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-windows-64@npm:0.13.13"
-  checksum: 8a9db43b1024128efd96b016e5aa189253f417918d35ff378df0244be94ede566e26248781d42885e57cf849ae873974016d3b40c44787c4b9b9b721ec8651fd
+"esbuild-windows-64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-windows-64@npm:0.13.15"
+  checksum: 58e6e9b050b9d6c337a6a6667fd5e4692efea630682484509a12f75298d44c3bd286b08c3b72b8478667986a2ccdd2dd61537668b36e779cda0c70e4a3b869dc
   languageName: node
   linkType: hard
 
-"esbuild-windows-arm64@npm:0.13.13":
-  version: 0.13.13
-  resolution: "esbuild-windows-arm64@npm:0.13.13"
-  checksum: ea3b3f2fcfb069bb26deaee5a8e01343b9c9e12933c14613860870b13a11fefe57e2eb3ba59273db4458c3b15e8cc5711672d8985c32fbbebddd380d35cb569d
+"esbuild-windows-arm64@npm:0.13.15":
+  version: 0.13.15
+  resolution: "esbuild-windows-arm64@npm:0.13.15"
+  checksum: 90dd0f13ebca09ad4640894bc1c6c1e2f8b4e69b6d808cbb01ef9fd469b6e4694523dd195abbc55a14f419e0dd204c4b35bcaca5b11194010da5fe7ba496b8a8
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.13.2":
-  version: 0.13.13
-  resolution: "esbuild@npm:0.13.13"
+"esbuild@npm:^0.13.12":
+  version: 0.13.15
+  resolution: "esbuild@npm:0.13.15"
   dependencies:
-    esbuild-android-arm64: 0.13.13
-    esbuild-darwin-64: 0.13.13
-    esbuild-darwin-arm64: 0.13.13
-    esbuild-freebsd-64: 0.13.13
-    esbuild-freebsd-arm64: 0.13.13
-    esbuild-linux-32: 0.13.13
-    esbuild-linux-64: 0.13.13
-    esbuild-linux-arm: 0.13.13
-    esbuild-linux-arm64: 0.13.13
-    esbuild-linux-mips64le: 0.13.13
-    esbuild-linux-ppc64le: 0.13.13
-    esbuild-netbsd-64: 0.13.13
-    esbuild-openbsd-64: 0.13.13
-    esbuild-sunos-64: 0.13.13
-    esbuild-windows-32: 0.13.13
-    esbuild-windows-64: 0.13.13
-    esbuild-windows-arm64: 0.13.13
+    esbuild-android-arm64: 0.13.15
+    esbuild-darwin-64: 0.13.15
+    esbuild-darwin-arm64: 0.13.15
+    esbuild-freebsd-64: 0.13.15
+    esbuild-freebsd-arm64: 0.13.15
+    esbuild-linux-32: 0.13.15
+    esbuild-linux-64: 0.13.15
+    esbuild-linux-arm: 0.13.15
+    esbuild-linux-arm64: 0.13.15
+    esbuild-linux-mips64le: 0.13.15
+    esbuild-linux-ppc64le: 0.13.15
+    esbuild-netbsd-64: 0.13.15
+    esbuild-openbsd-64: 0.13.15
+    esbuild-sunos-64: 0.13.15
+    esbuild-windows-32: 0.13.15
+    esbuild-windows-64: 0.13.15
+    esbuild-windows-arm64: 0.13.15
   dependenciesMeta:
     esbuild-android-arm64:
       optional: true
@@ -7127,7 +7127,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 41456ec911afce63ca2f0fb7829f4cb6bf721b0f39cf399f30f6a98ebcaca9f8c3921433096551920877fe38db049f9c31e63db62394c55a43d9b8a61ea36271
+  checksum: d60da8cd6f3642579034a2b971f0e0d6ea5191654789b43291be5a461aa8ab5c7faf2907188fcb9c6c0888246e8d2d941871a51f241ece39a40cbdd8117b6270
   languageName: node
   linkType: hard
 
@@ -7394,7 +7394,7 @@ __metadata:
     react: 17.0.2
     react-dom: 17.0.2
     storybook-builder-vite: "workspace:*"
-    vite: ^2.4.1
+    vite: 2.7.0-beta.4
   languageName: unknown
   linkType: soft
 
@@ -7410,7 +7410,7 @@ __metadata:
     "@sveltejs/vite-plugin-svelte": ^1.0.0-next.11
     storybook-builder-vite: "workspace:*"
     svelte: ^3.38.3
-    vite: ^2.4.1
+    vite: 2.7.0-beta.4
   languageName: unknown
   linkType: soft
 
@@ -7423,7 +7423,7 @@ __metadata:
     "@storybook/vue3": ^6.4.0
     "@vitejs/plugin-vue": ^1.2.4
     storybook-builder-vite: "workspace:*"
-    vite: ^2.4.1
+    vite: 2.7.0-beta.4
     vue: ^3.1.4
   languageName: unknown
   linkType: soft
@@ -11661,14 +11661,14 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.3.8":
-  version: 8.3.11
-  resolution: "postcss@npm:8.3.11"
+"postcss@npm:^8.3.11":
+  version: 8.4.4
+  resolution: "postcss@npm:8.4.4"
   dependencies:
     nanoid: ^3.1.30
     picocolors: ^1.0.0
-    source-map-js: ^0.6.2
-  checksum: fa1530f7e1817bcaf40b34db246d0c49e42daf12719abd4a3a1b5886491cca125af6b21ccdfc24a074ea9b6b73a6677e1478906adb732b2bd5208077a64473a6
+    source-map-js: ^1.0.1
+  checksum: 4408fae661d1308be030d6f3d55870fe9973f91239fb64687774fd3cce575dbab69c7cd54927e68bef49d7f8276a67cd46b6d6c3d4595bd341283fcd2cc0acb6
   languageName: node
   linkType: hard
 
@@ -12931,9 +12931,9 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"rollup@npm:^2.57.0":
-  version: 2.59.0
-  resolution: "rollup@npm:2.59.0"
+"rollup@npm:^2.59.0":
+  version: 2.60.2
+  resolution: "rollup@npm:2.60.2"
   dependencies:
     fsevents: ~2.3.2
   dependenciesMeta:
@@ -12941,7 +12941,7 @@ fsevents@^1.2.7:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 60843a071f55a7bc7d06cfa6367626264b17700d9f835e407a228cf1cb5ff11dab2c4536cc05297fdf0a35c79105236fa9e9d1c01728997f0e2d0b0df3de0555
+  checksum: d372b66d011fad84056cb6743aa5f3e86960d49658dc0e3f476bb5d6643162c359f103d09146dcb7587b6687966299bc9d3d94cf15accc17a79d6d98dd85db1f
   languageName: node
   linkType: hard
 
@@ -13424,6 +13424,13 @@ fsevents@^1.2.7:
   version: 0.6.2
   resolution: "source-map-js@npm:0.6.2"
   checksum: 8e2f992cfbedb71286fa6f6e011e2fa756b7f4d944ea4b0f49e9ff6ea34ad0a17dc655f067fdddb32efa7b45000e8c59e47a2e875d91744c86a56329b5f58b32
+  languageName: node
+  linkType: hard
+
+"source-map-js@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "source-map-js@npm:1.0.1"
+  checksum: 8096794b7d64f9bc74738f6b8731cbd9f32d81384b16d3bea55ac8bc69fd80e1b8cfb99d638b4c6df5c111ce363c55b4b51a8abd9e609357460c82305ee59471
   languageName: node
   linkType: hard
 
@@ -14837,15 +14844,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"vite@npm:^2.4.1":
-  version: 2.6.13
-  resolution: "vite@npm:2.6.13"
+"vite@npm:2.7.0-beta.4":
+  version: 2.7.0-beta.4
+  resolution: "vite@npm:2.7.0-beta.4"
   dependencies:
-    esbuild: ^0.13.2
+    esbuild: ^0.13.12
     fsevents: ~2.3.2
-    postcss: ^8.3.8
+    postcss: ^8.3.11
     resolve: ^1.20.0
-    rollup: ^2.57.0
+    rollup: ^2.59.0
   peerDependencies:
     less: "*"
     sass: "*"
@@ -14862,7 +14869,7 @@ fsevents@^1.2.7:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 01451c7a4f26b19d04b3d88464d9eb521e8633cb4a02e7b4dc771e5fc3bb502e529de6b71ebd901d725a9e3e8cf19be196f00e76eb3ac196e87a5b4b4f4b6baa
+  checksum: f5a3ebeda3ac58d328936d678d283264f680befac2b092bccccbdc913be5f28cb27ad9e60c6f54ac2edd6abc973f753a7a4260690984680007a38db78a0f202d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #171 

Also updates our examples to 2.7.0.

I also tested this change before updating the examples, and confirmed it works with vite 2.6 as well.