### PR TITLE
Fix: all environment variables are exposed to the client

### DIFF
--- a/packages/example-react/.env
+++ b/packages/example-react/.env
@@ -1,0 +1,3 @@
+STORYBOOK_ENV_VAR=included
+VITE_ENV_VAR=included
+ENV_VAR=should_not_be_included

--- a/packages/example-react/stories/EnvironmentVariables.jsx
+++ b/packages/example-react/stories/EnvironmentVariables.jsx
@@ -6,6 +6,12 @@ export function EnvironmentVariables() {
       <div>{JSON.stringify(import.meta.env, null, 2)}</div>
       <h1>import . meta . env . STORYBOOK:</h1>
       <div>{import.meta.env.STORYBOOK}</div>
+      <h1>import . meta . env . STORYBOOK_ENV_VAR:</h1>
+      <div>{import.meta.env.STORYBOOK_ENV_VAR}</div>
+      <h1>import . meta . env . VITE_ENV_VAR:</h1>
+      <div>{import.meta.env.VITE_ENV_VAR}</div>
+      <h1>import . meta . env . ENV_VAR:</h1>
+      <div>{import.meta.env.ENV_VAR}</div>
     </div>
   )
 }

--- a/packages/example-workspaces/.env
+++ b/packages/example-workspaces/.env
@@ -1,0 +1,3 @@
+STORYBOOK_ENV_VAR=included
+VITE_ENV_VAR=included
+ENV_VAR=should_not_be_included

--- a/packages/example-workspaces/packages/app/stories/EnvironmentVariables.jsx
+++ b/packages/example-workspaces/packages/app/stories/EnvironmentVariables.jsx
@@ -6,6 +6,12 @@ export function EnvironmentVariables() {
       <div>{JSON.stringify(import.meta.env, null, 2)}</div>
       <h1>import . meta . env . STORYBOOK:</h1>
       <div>{import.meta.env.STORYBOOK}</div>
+      <h1>import . meta . env . STORYBOOK_ENV_VAR:</h1>
+      <div>{import.meta.env.STORYBOOK_ENV_VAR}</div>
+      <h1>import . meta . env . VITE_ENV_VAR:</h1>
+      <div>{import.meta.env.VITE_ENV_VAR}</div>
+      <h1>import . meta . env . ENV_VAR:</h1>
+      <div>{import.meta.env.ENV_VAR}</div>
     </div>
   )
 }

--- a/packages/storybook-builder-vite/build.js
+++ b/packages/storybook-builder-vite/build.js
@@ -5,8 +5,6 @@ const { build: viteBuild } = require('vite');
 
 module.exports.build = async function build(options) {
     const { presets } = options;
-    const envsRaw = await presets.apply('env');
-    const envs = stringifyProcessEnvs(envsRaw);
 
     const config = {
         configFile: false,
@@ -31,5 +29,15 @@ module.exports.build = async function build(options) {
         config,
         options
     );
+
+    const envsRaw = await presets.apply('env');
+    // Stringify env variables after getting `envPrefix` from the final config
+    const envs = stringifyProcessEnvs(envsRaw, finalConfig.envPrefix);
+    // Update `define`
+    finalConfig.define = {
+        ...finalConfig.define,
+        ...envs,
+    }
+
     await viteBuild(finalConfig);
 };

--- a/packages/storybook-builder-vite/build.js
+++ b/packages/storybook-builder-vite/build.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { stringifyProcessEnvs } = require('./envs');
+const { stringifyProcessEnvs, allowedEnvPrefix: envPrefix } = require('./envs');
 const { pluginConfig } = require('./vite-config');
 const { build: viteBuild } = require('vite');
 
@@ -16,7 +16,8 @@ module.exports.build = async function build(options) {
             emptyOutDir: false, // do not clean before running Vite build - Storybook has already added assets in there!
             sourcemap: true,
         },
-        define: envs,
+        envPrefix,
+        define: {},
         resolve: {
             alias: {
                 vue: 'vue/dist/vue.esm-bundler.js',

--- a/packages/storybook-builder-vite/envs.js
+++ b/packages/storybook-builder-vite/envs.js
@@ -20,7 +20,7 @@ module.exports.allowedEnvPrefix = [
 
 /**
  * Customized version of stringifyProcessEnvs from @storybook/core-common which
- * uses import.meta.env instead of process.env
+ * uses import.meta.env instead of process.env and checks for allowed variables.
  * @param {Object<string, string>} raw
  * @param {string[]|string} envPrefix
  */
@@ -29,10 +29,10 @@ module.exports.stringifyProcessEnvs = function stringifyProcessEnvs(raw, envPref
   const envs = Object.entries(raw).reduce(
     (acc, [key, value]) => {
       // Only add allowed values OR values from array OR string started with allowed prefixes
-      if (allowedEnvVariables.indexOf(key) >= 0
+      if (allowedEnvVariables.includes(key)
         || (
-          (Array.isArray(envPrefix) && !!envPrefix.find((prefix) => key.indexOf(prefix) === 0))
-          || key.indexOf(envPrefix) === 0
+          (Array.isArray(envPrefix) && !!envPrefix.find((prefix) => key.startsWith(prefix)))
+          || key.startsWith(envPrefix)
         )) {
         acc[`import.meta.env.${key}`] = JSON.stringify(value);
         updatedRaw[key] = value;

--- a/packages/storybook-builder-vite/envs.js
+++ b/packages/storybook-builder-vite/envs.js
@@ -1,5 +1,23 @@
 const { stringifyEnvs } = require('@storybook/core-common')
 
+// Allowed env variables on the client
+const allowedEnvVariables = [
+  'STORYBOOK',
+  // Vite `import.meta.env` default variables
+  // @see https://github.com/vitejs/vite/blob/6b8d94dca2a1a8b4952e3e3fcd0aed1aedb94215/packages/vite/types/importMeta.d.ts#L68-L75
+  'BASE_URL',
+  'MODE',
+  'DEV',
+  'PROD',
+  'SSR',
+];
+
+// Env variables starts with env prefix will be exposed to your client source code via `import.meta.env`
+module.exports.allowedEnvPrefix = [
+  'VITE_',
+  'STORYBOOK_'
+];
+
 /**
 * Customized version of stringifyProcessEnvs from @storybook/core-common which
 * uses import.meta.env instead of process.env

--- a/packages/storybook-builder-vite/envs.js
+++ b/packages/storybook-builder-vite/envs.js
@@ -25,9 +25,18 @@ module.exports.allowedEnvPrefix = [
  * @param {string[]|string} envPrefix
  */
 module.exports.stringifyProcessEnvs = function stringifyProcessEnvs(raw, envPrefix) {
+  const updatedRaw = {};
   const envs = Object.entries(raw).reduce(
     (acc, [key, value]) => {
-      acc[`import.meta.env.${key}`] = JSON.stringify(value);
+      // Only add allowed values OR values from array OR string started with allowed prefixes
+      if (allowedEnvVariables.indexOf(key) >= 0
+        || (
+          (Array.isArray(envPrefix) && !!envPrefix.find((prefix) => key.indexOf(prefix) === 0))
+          || key.indexOf(envPrefix) === 0
+        )) {
+        acc[`import.meta.env.${key}`] = JSON.stringify(value);
+        updatedRaw[key] = value;
+      }
       return acc;
     },
     {
@@ -37,6 +46,7 @@ module.exports.stringifyProcessEnvs = function stringifyProcessEnvs(raw, envPref
   );
   // support destructuring like
   // const { foo } = import.meta.env;
-  envs['import.meta.env'] = JSON.stringify(stringifyEnvs(raw));
+  envs['import.meta.env'] = JSON.stringify(stringifyEnvs(updatedRaw));
+
   return envs;
 }

--- a/packages/storybook-builder-vite/envs.js
+++ b/packages/storybook-builder-vite/envs.js
@@ -19,10 +19,12 @@ module.exports.allowedEnvPrefix = [
 ];
 
 /**
-* Customized version of stringifyProcessEnvs from @storybook/core-common which
-* uses import.meta.env instead of process.env
-*/
-module.exports.stringifyProcessEnvs = function stringifyProcessEnvs(raw) {
+ * Customized version of stringifyProcessEnvs from @storybook/core-common which
+ * uses import.meta.env instead of process.env
+ * @param {Object<string, string>} raw
+ * @param {string[]|string} envPrefix
+ */
+module.exports.stringifyProcessEnvs = function stringifyProcessEnvs(raw, envPrefix) {
   const envs = Object.entries(raw).reduce(
     (acc, [key, value]) => {
       acc[`import.meta.env.${key}`] = JSON.stringify(value);

--- a/packages/storybook-builder-vite/vite-server.js
+++ b/packages/storybook-builder-vite/vite-server.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const {stringifyProcessEnvs} = require('./envs');
+const { stringifyProcessEnvs, allowedEnvPrefix: envPrefix } = require('./envs');
 const { getOptimizeDeps } = require('./optimizeDeps');
 const { createServer } = require('vite');
 const { pluginConfig } = require('./vite-config');
@@ -27,7 +27,8 @@ module.exports.createViteServer = async function createViteServer(
                 strict: true,
             },
         },
-        define: envs,
+        envPrefix,
+        define: {},
         resolve: {
             alias: {
                 vue: 'vue/dist/vue.esm-bundler.js',

--- a/packages/storybook-builder-vite/vite-server.js
+++ b/packages/storybook-builder-vite/vite-server.js
@@ -10,8 +10,6 @@ module.exports.createViteServer = async function createViteServer(
 ) {
     const { port, presets } = options;
     const root = path.resolve(options.configDir, '..');
-    const envsRaw = await presets.apply('env');
-    const envs = stringifyProcessEnvs(envsRaw);
 
     const defaultConfig = {
         configFile: false,
@@ -43,6 +41,16 @@ module.exports.createViteServer = async function createViteServer(
         defaultConfig,
         options
     );
+
+    const envsRaw = await presets.apply('env');
+    // Stringify env variables after getting `envPrefix` from the final config
+    const envs = stringifyProcessEnvs(envsRaw, finalConfig.envPrefix);
+    // Update `define`
+    finalConfig.define = {
+      ...finalConfig.define,
+      ...envs,
+    }
+
     return createServer(finalConfig);
 };
 


### PR DESCRIPTION
Greetings.

This pull request fixes: #185 

Rules based on:

* [Storybook — Environment variables](https://storybook.js.org/docs/react/configure/environment-variables)
* [Vite — Env Variables and Modes](https://vitejs.dev/guide/env-and-mode.html)

## Allowed on the client

### Environment variables prefixes

* `STORYBOOK_`;
* `VITE_`.

Used for setup default [`envPrefix`](https://vitejs.dev/config/index.html#envprefix) value in Vite config.

### Environment variables

* Storybook:
  * `STORYBOOK`;
* Vite:
  * `BASE_URL`;
  * `MODE`;
  * `DEV`;
  * `PROD`;
  * `SSR`.
  
Used for filtering.

Best wishes,
Sergey.