### PR TITLE
Avoid forcing prebundle each start

### DIFF
--- a/packages/storybook-builder-vite/vite-server.js
+++ b/packages/storybook-builder-vite/vite-server.js
@@ -15,7 +15,6 @@ module.exports.createViteServer = async function createViteServer(
         configFile: false,
         root,
         server: {
-            force: true,
             middlewareMode: true,
             hmr: {
                 port,


### PR DESCRIPTION
Fixes #90 

There doesn't seem to be a need to re-prebundle each time the server starts.