### PR TITLE
Publish Storybooks to Chromatic as part of build

### DIFF
--- a/.github/workflows/buildExamples.yml
+++ b/.github/workflows/buildExamples.yml
@@ -36,3 +36,8 @@ jobs:
 
       - name: Build examples
         run: yarn workspaces foreach -p run build-storybook
+
+      - name: Publish examples to Chromatic
+        run: yarn workspaces foreach -p run publish-chromatic
+        if: ${{ github.event.pull_request.head.repo.full_name == 'eirslett/storybook-builder-vite' }}
+

--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -6,7 +6,8 @@
     "main": "index.js",
     "scripts": {
         "storybook": "start-storybook",
-        "build-storybook": "build-storybook"
+        "build-storybook": "build-storybook",
+        "publish-chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
     },
     "author": "",
     "license": "MIT",
@@ -19,6 +20,7 @@
         "@storybook/addon-docs": "^6.4.0",
         "@storybook/addon-essentials": "^6.4.0",
         "@storybook/react": "^6.4.0",
+        "chromatic": "^6.3.3",
         "storybook-builder-vite": "workspace:*",
         "vite": "2.7.0"
     }

--- a/packages/example-svelte/package.json
+++ b/packages/example-svelte/package.json
@@ -20,6 +20,7 @@
         "@storybook/addon-svelte-csf": "^1.1.0",
         "@storybook/svelte": "^6.4.0",
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",
+        "chromatic": "^6.3.3",
         "storybook-builder-vite": "workspace:*",
         "vite": "2.7.0"
     }

--- a/packages/example-vue/package.json
+++ b/packages/example-vue/package.json
@@ -18,6 +18,7 @@
         "@storybook/addon-essentials": "^6.4.0",
         "@storybook/vue3": "^6.4.0",
         "@vitejs/plugin-vue": "^1.2.4",
+        "chromatic": "^6.3.3",
         "storybook-builder-vite": "workspace:*",
         "vite": "2.7.0"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5656,6 +5656,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chromatic@npm:^6.3.3":
+  version: 6.3.3
+  resolution: "chromatic@npm:6.3.3"
+  bin:
+    chroma: bin/main.cjs
+    chromatic: bin/main.cjs
+    chromatic-cli: bin/main.cjs
+  checksum: 37aad4ac0d95634c23fec014d58c66740d8a7cc2364350afd07e48c385907457f63380ca432faf1876466bc2af8b1598c34e9dd9d3f8aac088ee4b9ef7bc6df2
+  languageName: node
+  linkType: hard
+
 "chrome-trace-event@npm:^1.0.2":
   version: 1.0.3
   resolution: "chrome-trace-event@npm:1.0.3"
@@ -7391,6 +7402,7 @@ __metadata:
     "@storybook/addon-docs": ^6.4.0
     "@storybook/addon-essentials": ^6.4.0
     "@storybook/react": ^6.4.0
+    chromatic: ^6.3.3
     react: 17.0.2
     react-dom: 17.0.2
     storybook-builder-vite: "workspace:*"
@@ -7408,6 +7420,7 @@ __metadata:
     "@storybook/addon-svelte-csf": ^1.1.0
     "@storybook/svelte": ^6.4.0
     "@sveltejs/vite-plugin-svelte": ^1.0.0-next.11
+    chromatic: ^6.3.3
     storybook-builder-vite: "workspace:*"
     svelte: ^3.38.3
     vite: 2.7.0
@@ -7422,6 +7435,7 @@ __metadata:
     "@storybook/addon-essentials": ^6.4.0
     "@storybook/vue3": ^6.4.0
     "@vitejs/plugin-vue": ^1.2.4
+    chromatic: ^6.3.3
     storybook-builder-vite: "workspace:*"
     vite: 2.7.0
     vue: ^3.1.4


### PR DESCRIPTION
Let's see if this works! `$CHROMATIC_PROJECT_TOKEN` is added to this repository as a secret, so that it can be used from GitHub Actions.

According to Chromatic docs, permissions to Chromatic should be synced with permissions to this repo. So I think you have access there now.
