### PR TITLE
Add CSF3 default render example

### DIFF
--- a/packages/example-react/stories/Button.stories.jsx
+++ b/packages/example-react/stories/Button.stories.jsx
@@ -8,27 +8,29 @@ export default {
   },
 };
 
-const Template = (args) => <Button {...args} />;
-
-export const Primary = Template.bind({});
-Primary.args = {
-  primary: true,
-  label: 'Button',
+export const Primary = {
+  args: {
+    primary: true,
+    label: 'Button',
+  },
 };
 
-export const Secondary = Template.bind({});
-Secondary.args = {
-  label: 'Button',
+export const Secondary = {
+  args: {
+    label: 'Button',
+  },
 };
 
-export const Large = Template.bind({});
-Large.args = {
-  size: 'large',
-  label: 'Button',
+export const Large = {
+  args: {
+    size: 'large',
+    label: 'Button',
+  },
 };
 
-export const Small = Template.bind({});
-Small.args = {
-  size: 'small',
-  label: 'Button',
+export const Small = {
+  args: {
+    size: 'small',
+    label: 'Button',
+  },
 };


### PR DESCRIPTION
This supersedes #76 which attempted to add support for CSF3 default render functions. This is now supported by the core in 6.4, which means that no changes are needed in the Vite builder apparently. I added an example to test it out and am closing #76.

Documentation here https://storybook.js.org/docs/7.0/react/writing-stories/introduction#using-args