### PR TITLE
Improving maintainability: fix ignore revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
-# Ran `lint` script
-692d7a64d58ac04d32563dae69b43fbd1e293366
+# Improving maintainability: run `lint` (#196)
+00a32cfd74494e979afa543b02d38fe697a845a1


### PR DESCRIPTION
Hello.

Updated a commit id in the `.git-blame-ignore-revs` file, because commit id was changed after squash merge.

@eirslett, @IanVS 

Please, do not use the squash merge method, because it's:

* breaks commit IDs, as result the `.git-blame-ignore-revs` file have wrong IDs;
* breaks ability to merge branches with same commits (on top of each other), so we are need to manually rebase inherit branches after every squash merge.

Best wishes,
Sergey.