### PR TITLE
Remove unfetch import

### DIFF
--- a/packages/storybook-builder-vite/codegen-modern-iframe-script.ts
+++ b/packages/storybook-builder-vite/codegen-modern-iframe-script.ts
@@ -28,9 +28,6 @@ export async function generateModernIframeScriptCode(
    */
   // language=JavaScript
   const code = `
-    // TODO: Check if the 'unfetch' package is used 
-    // noinspection ES6UnusedImports
-    import fetch from 'unfetch';
     import global from 'global';
 
     import { composeConfigs, PreviewWeb } from '@storybook/preview-web';


### PR DESCRIPTION
Copying [#17306](https://github.com/storybookjs/storybook/pull/17306). I thought it was unneccessary but, now it's been removed we can safely remove it too.