### PR TITLE
Enable auto-title for non-storyStoreV7

### DIFF
--- a/packages/example-react/.storybook/main.js
+++ b/packages/example-react/.storybook/main.js
@@ -6,7 +6,7 @@ module.exports = {
     builder: 'storybook-builder-vite',
   },
   features: {
-    storyStoreV7: true,
+    storyStoreV7: false,
   },
   async viteFinal(config, { configType }) {
     // customize the Vite config here

--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -15,10 +15,10 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@storybook/addon-a11y": "^6.4.0",
-    "@storybook/addon-docs": "^6.4.0",
-    "@storybook/addon-essentials": "^6.4.0",
-    "@storybook/react": "^6.4.0",
+    "@storybook/addon-a11y": "^6.4.14",
+    "@storybook/addon-docs": "^6.4.14",
+    "@storybook/addon-essentials": "^6.4.14",
+    "@storybook/react": "^6.4.14",
     "storybook-builder-vite": "workspace:*",
     "vite": "2.7.0"
   }

--- a/packages/example-react/stories/Button.stories.jsx
+++ b/packages/example-react/stories/Button.stories.jsx
@@ -1,7 +1,6 @@
 import { Button } from './Button';
 
 export default {
-  title: 'Example/Button',
   component: Button,
   argTypes: {
     backgroundColor: { control: 'color' },

--- a/packages/example-react/stories/Button.stories.jsx
+++ b/packages/example-react/stories/Button.stories.jsx
@@ -1,6 +1,7 @@
 import { Button } from './Button';
 
 export default {
+  // no title, to demonstrate autotitle
   component: Button,
   argTypes: {
     backgroundColor: { control: 'color' },

--- a/packages/example-svelte/package.json
+++ b/packages/example-svelte/package.json
@@ -14,11 +14,11 @@
     "svelte": "^3.46.4"
   },
   "devDependencies": {
-    "@storybook/addon-actions": "^6.4.0",
-    "@storybook/addon-essentials": "^6.4.0",
-    "@storybook/addon-links": "^6.4.0",
+    "@storybook/addon-actions": "^6.4.14",
+    "@storybook/addon-essentials": "^6.4.14",
+    "@storybook/addon-links": "^6.4.14",
     "@storybook/addon-svelte-csf": "^1.1.0",
-    "@storybook/svelte": "^6.4.0",
+    "@storybook/svelte": "^6.4.14",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.37",
     "storybook-builder-vite": "workspace:*",
     "vite": "2.7.0"

--- a/packages/example-vue/package.json
+++ b/packages/example-vue/package.json
@@ -14,9 +14,9 @@
     "vue": "^3.1.4"
   },
   "devDependencies": {
-    "@storybook/addon-a11y": "^6.4.0",
-    "@storybook/addon-essentials": "^6.4.0",
-    "@storybook/vue3": "^6.4.0",
+    "@storybook/addon-a11y": "^6.4.14",
+    "@storybook/addon-essentials": "^6.4.14",
+    "@storybook/vue3": "^6.4.14",
     "@vitejs/plugin-vue": "^1.10.2",
     "storybook-builder-vite": "workspace:*",
     "vite": "2.7.0"

--- a/packages/example-workspaces/packages/catalog/package.json
+++ b/packages/example-workspaces/packages/catalog/package.json
@@ -15,10 +15,10 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@storybook/addon-a11y": "^6.4.0",
-    "@storybook/addon-docs": "^6.4.0",
-    "@storybook/addon-essentials": "^6.4.0",
-    "@storybook/react": "^6.4.0",
+    "@storybook/addon-a11y": "^6.4.14",
+    "@storybook/addon-docs": "^6.4.14",
+    "@storybook/addon-essentials": "^6.4.14",
+    "@storybook/react": "^6.4.14",
     "storybook-builder-vite": "workspace:*",
     "vite": "2.7.0"
   }

--- a/packages/storybook-builder-vite/input/iframe.html
+++ b/packages/storybook-builder-vite/input/iframe.html
@@ -11,6 +11,7 @@
       window.FRAMEWORK_OPTIONS = '[FRAMEWORK_OPTIONS HERE]';
       window.CHANNEL_OPTIONS = '[CHANNEL_OPTIONS HERE]';
       window.FEATURES = '[FEATURES HERE]';
+      window.STORIES = '[STORIES HERE]';
       window.SERVER_CHANNEL_URL = '[SERVER_CHANNEL_URL HERE]';
 
       // We do this so that "module && module.hot" etc. in Storybook source code

--- a/packages/storybook-builder-vite/transform-iframe-html.ts
+++ b/packages/storybook-builder-vite/transform-iframe-html.ts
@@ -1,17 +1,23 @@
+import { normalizeStories } from '@storybook/core-common';
 import type { CoreConfig } from '@storybook/core-common';
 import type { ExtendedOptions } from './types';
 
 export type PreviewHtml = string | undefined;
 
-export async function transformIframeHtml(
-  html: string,
-  { configType, features, framework, presets, serverChannelUrl, title }: ExtendedOptions
-) {
+export async function transformIframeHtml(html: string, options: ExtendedOptions) {
+  const { configType, features, framework, presets, serverChannelUrl, title } = options;
   const headHtmlSnippet = await presets.apply<PreviewHtml>('previewHead');
   const bodyHtmlSnippet = await presets.apply<PreviewHtml>('previewBody');
   const logLevel = await presets.apply('logLevel', undefined);
   const frameworkOptions = await presets.apply(`${framework}Options`, {});
   const coreOptions = await presets.apply<CoreConfig>('core');
+  const stories = normalizeStories(await options.presets.apply('stories', [], options), {
+    configDir: options.configDir,
+    workingDir: process.cwd(),
+  }).map((specifier) => ({
+    ...specifier,
+    importPathMatcher: specifier.importPathMatcher.source,
+  }));
 
   return html
     .replace('<!-- [TITLE HERE] -->', title || 'Storybook')
@@ -23,6 +29,7 @@ export async function transformIframeHtml(
       JSON.stringify(coreOptions && coreOptions.channelOptions ? coreOptions.channelOptions : {})
     )
     .replace(`'[FEATURES HERE]'`, JSON.stringify(features || {}))
+    .replace(`'[STORIES HERE]'`, JSON.stringify(stories || {}))
     .replace(`'[SERVER_CHANNEL_URL HERE]'`, JSON.stringify(serverChannelUrl))
     .replace('<!-- [HEAD HTML SNIPPET HERE] -->', headHtmlSnippet || '')
     .replace('<!-- [BODY HTML SNIPPET HERE] -->', bodyHtmlSnippet || '');

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,15 +12,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:7.10.4":
-  version: 7.10.4
-  resolution: "@babel/code-frame@npm:7.10.4"
-  dependencies:
-    "@babel/highlight": ^7.10.4
-  checksum: feb4543c8a509fe30f0f6e8d7aa84f82b41148b963b826cd330e34986f649a85cb63b2f13dd4effdf434ac555d16f14940b8ea5f4433297c2f5ff85486ded019
-  languageName: node
-  linkType: hard
-
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.14.5, @babel/code-frame@npm:^7.5.5, @babel/code-frame@npm:^7.8.3":
   version: 7.14.5
   resolution: "@babel/code-frame@npm:7.14.5"
@@ -549,7 +540,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/highlight@npm:^7.10.4, @babel/highlight@npm:^7.14.5":
+"@babel/highlight@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/highlight@npm:7.14.5"
   dependencies:
@@ -2230,21 +2221,21 @@ __metadata:
   linkType: hard
 
 "@storybook/addon-a11y@npm:^6.4.0":
-  version: 6.4.3
-  resolution: "@storybook/addon-a11y@npm:6.4.3"
+  version: 6.4.19
+  resolution: "@storybook/addon-a11y@npm:6.4.19"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/api": 6.4.3
-    "@storybook/channels": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/components": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@storybook/addons": 6.4.19
+    "@storybook/api": 6.4.19
+    "@storybook/channels": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/components": 6.4.19
+    "@storybook/core-events": 6.4.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.3
+    "@storybook/theming": 6.4.19
     axe-core: ^4.2.0
     core-js: ^3.8.2
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     react-sizeme: ^3.0.1
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
@@ -2257,24 +2248,56 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 44e53ce1ffda482802954fe5a3defe36e7a090624ec621034f6584dc80d0aaef9ebca7fc9b1c2af91b8d99282089965b1bb5a8964f535ec29639405af2b91696
+  checksum: a7e6f544773cd6e515c88d4051ead0cae482d1df4960e8a28d4c45170814a55e56ee5433889dfc87df1d70cf587fe881fb39d042c411fa12a6c09bea21ceb2ef
   languageName: node
   linkType: hard
 
-"@storybook/addon-actions@npm:6.4.3, @storybook/addon-actions@npm:^6.4.0":
-  version: 6.4.3
-  resolution: "@storybook/addon-actions@npm:6.4.3"
+"@storybook/addon-a11y@npm:^6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/addon-a11y@npm:6.4.14"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/api": 6.4.3
-    "@storybook/components": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@storybook/addons": 6.4.14
+    "@storybook/api": 6.4.14
+    "@storybook/channels": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/components": 6.4.14
+    "@storybook/core-events": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.3
+    "@storybook/theming": 6.4.14
+    axe-core: ^4.2.0
+    core-js: ^3.8.2
+    global: ^4.4.0
+    lodash: ^4.17.21
+    react-sizeme: ^3.0.1
+    regenerator-runtime: ^0.13.7
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: ce472e2e6e01da3e775bb80b3bb2f30ffec3e4968121970b84ccdc7803c54a9c9640ebc64bf400f5108b0de8b9fdf52995504252c976804501d905e3a14a2f06
+  languageName: node
+  linkType: hard
+
+"@storybook/addon-actions@npm:6.4.14, @storybook/addon-actions@npm:^6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/addon-actions@npm:6.4.14"
+  dependencies:
+    "@storybook/addons": 6.4.14
+    "@storybook/api": 6.4.14
+    "@storybook/components": 6.4.14
+    "@storybook/core-events": 6.4.14
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/theming": 6.4.14
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     polished: ^4.0.5
     prop-types: ^15.7.2
     react-inspector: ^5.1.0
@@ -2291,21 +2314,55 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 8418a1486230d932ff03f27de265111de8d6aefd60f496d2401991f7e54393d8e8879df8ba8b9a3c17c1469707f76dac6b87dde8e928462556e1614182ae3885
+  checksum: f5d563eef0133fa47005184117af00af89514183a34672d15695105a864aac87fa10adafe6e559fab5783c39d28375a68ad019587249ff5c2f1bad4a56e6a1e9
   languageName: node
   linkType: hard
 
-"@storybook/addon-backgrounds@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/addon-backgrounds@npm:6.4.3"
+"@storybook/addon-actions@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/addon-actions@npm:6.4.19"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/api": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/components": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@storybook/addons": 6.4.19
+    "@storybook/api": 6.4.19
+    "@storybook/components": 6.4.19
+    "@storybook/core-events": 6.4.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.3
+    "@storybook/theming": 6.4.19
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    polished: ^4.0.5
+    prop-types: ^15.7.2
+    react-inspector: ^5.1.0
+    regenerator-runtime: ^0.13.7
+    telejson: ^5.3.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+    uuid-browser: ^3.1.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: ff09bfdd773c551fdfbc055e740aba0c4f75d8ca3e04e3bcff85f3d2afb792634a87901f16af7d64720c328b6cfcf76a65eea40301e40b461df26a80b45913ff
+  languageName: node
+  linkType: hard
+
+"@storybook/addon-backgrounds@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/addon-backgrounds@npm:6.4.14"
+  dependencies:
+    "@storybook/addons": 6.4.14
+    "@storybook/api": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/components": 6.4.14
+    "@storybook/core-events": 6.4.14
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/theming": 6.4.14
     core-js: ^3.8.2
     global: ^4.4.0
     memoizerific: ^1.11.3
@@ -2320,25 +2377,54 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: a8809bd09ba39f9818e3924fbb33a9d3ebbe4c160a4864d74cd4e1cacd6f5d97b3d8520969ee7c868e173c4aaf1cd326d620392c8b86a0f3da5ab0151307647d
+  checksum: 4c10550789b4b748b086f6a433ee6824c4861e2fc3597c5e10646058309f446b0ff4dfa334bc4beb9001ba0f277a56d0bab3ec95d52a3bec8bd921b764673954
   languageName: node
   linkType: hard
 
-"@storybook/addon-controls@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/addon-controls@npm:6.4.3"
+"@storybook/addon-backgrounds@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/addon-backgrounds@npm:6.4.19"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/api": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/components": 6.4.3
-    "@storybook/core-common": 6.4.3
+    "@storybook/addons": 6.4.19
+    "@storybook/api": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/components": 6.4.19
+    "@storybook/core-events": 6.4.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/node-logger": 6.4.3
-    "@storybook/store": 6.4.3
-    "@storybook/theming": 6.4.3
+    "@storybook/theming": 6.4.19
     core-js: ^3.8.2
-    lodash: ^4.17.20
+    global: ^4.4.0
+    memoizerific: ^1.11.3
+    regenerator-runtime: ^0.13.7
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 338d844b185ab4e9bf099d39e8e6c077e3804db1eea5651c73717ece1320926e89eec178075437bf2385e255e2e47af7872671cc2fd0bbcd8e212f6169a5f91d
+  languageName: node
+  linkType: hard
+
+"@storybook/addon-controls@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/addon-controls@npm:6.4.14"
+  dependencies:
+    "@storybook/addons": 6.4.14
+    "@storybook/api": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/components": 6.4.14
+    "@storybook/core-common": 6.4.14
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/node-logger": 6.4.14
+    "@storybook/store": 6.4.14
+    "@storybook/theming": 6.4.14
+    core-js: ^3.8.2
+    lodash: ^4.17.21
     ts-dedent: ^2.0.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
@@ -2348,13 +2434,41 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: d54767168a1f975e80e5120e6af2f3f0942aae0395a616bc56b59d38cebda7039de42a22c16715680e7bea09a59e7c5bcece44b76cb211a8449c945449a3de5e
+  checksum: 4adb29a3be1d4184c4aad3df32d3a088309a6a69602991d496c2e0faef7a3dacb639c5d89c8e019c606554c1180fd7eaea34e2f2604713adc16f5aa44f5ef9cc
   languageName: node
   linkType: hard
 
-"@storybook/addon-docs@npm:6.4.3, @storybook/addon-docs@npm:^6.4.0":
-  version: 6.4.3
-  resolution: "@storybook/addon-docs@npm:6.4.3"
+"@storybook/addon-controls@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/addon-controls@npm:6.4.19"
+  dependencies:
+    "@storybook/addons": 6.4.19
+    "@storybook/api": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/components": 6.4.19
+    "@storybook/core-common": 6.4.19
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/node-logger": 6.4.19
+    "@storybook/store": 6.4.19
+    "@storybook/theming": 6.4.19
+    core-js: ^3.8.2
+    lodash: ^4.17.21
+    ts-dedent: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 352c2bc79796b82c9122cfd9d9985dd53bf7b13aad6e5e899fbe0f5078c0e1a8d2ad6d37138b7599aa4e0c649987d6f295ddd20c184adda0b329157bb69587a6
+  languageName: node
+  linkType: hard
+
+"@storybook/addon-docs@npm:6.4.14, @storybook/addon-docs@npm:^6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/addon-docs@npm:6.4.14"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/generator": ^7.12.11
@@ -2365,21 +2479,21 @@ __metadata:
     "@mdx-js/loader": ^1.6.22
     "@mdx-js/mdx": ^1.6.22
     "@mdx-js/react": ^1.6.22
-    "@storybook/addons": 6.4.3
-    "@storybook/api": 6.4.3
-    "@storybook/builder-webpack4": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/components": 6.4.3
-    "@storybook/core": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@storybook/addons": 6.4.14
+    "@storybook/api": 6.4.14
+    "@storybook/builder-webpack4": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/components": 6.4.14
+    "@storybook/core": 6.4.14
+    "@storybook/core-events": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/csf-tools": 6.4.3
-    "@storybook/node-logger": 6.4.3
-    "@storybook/postinstall": 6.4.3
-    "@storybook/preview-web": 6.4.3
-    "@storybook/source-loader": 6.4.3
-    "@storybook/store": 6.4.3
-    "@storybook/theming": 6.4.3
+    "@storybook/csf-tools": 6.4.14
+    "@storybook/node-logger": 6.4.14
+    "@storybook/postinstall": 6.4.14
+    "@storybook/preview-web": 6.4.14
+    "@storybook/source-loader": 6.4.14
+    "@storybook/store": 6.4.14
+    "@storybook/theming": 6.4.14
     acorn: ^7.4.1
     acorn-jsx: ^5.3.1
     acorn-walk: ^7.2.0
@@ -2391,10 +2505,10 @@ __metadata:
     html-tags: ^3.1.0
     js-string-escape: ^1.0.1
     loader-utils: ^2.0.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     nanoid: ^3.1.23
     p-limit: ^3.1.0
-    prettier: ^2.2.1
+    prettier: ">=2.2.1 <=2.3.0"
     prop-types: ^15.7.2
     react-element-to-jsx-string: ^14.3.4
     regenerator-runtime: ^0.13.7
@@ -2403,12 +2517,12 @@ __metadata:
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
   peerDependencies:
-    "@storybook/angular": 6.4.3
-    "@storybook/html": 6.4.3
-    "@storybook/react": 6.4.3
-    "@storybook/vue": 6.4.3
-    "@storybook/vue3": 6.4.3
-    "@storybook/web-components": 6.4.3
+    "@storybook/angular": 6.4.14
+    "@storybook/html": 6.4.14
+    "@storybook/react": 6.4.14
+    "@storybook/vue": 6.4.14
+    "@storybook/vue3": 6.4.14
+    "@storybook/web-components": 6.4.14
     lit: ^2.0.0
     lit-html: ^1.4.1 || ^2.0.0
     react: ^16.8.0 || ^17.0.0
@@ -2446,32 +2560,130 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 798a08fb44439b48322e98ee18c6fae1da96362c1e4f1b45abfadcc538a307ba703dbc10ae147227a96796d37075e76427dc686e5847b0e05170e9e0f0a557f0
+  checksum: 8bba097bdd58dea93ef51f7ec2c4acf2a11b9b84395d9337a45af4df1bc01c9e9afc88ab8566e24ed1044c43eaa24d1baf01c9f7bb651b72ad5b8886fd8eb32a
+  languageName: node
+  linkType: hard
+
+"@storybook/addon-docs@npm:6.4.19, @storybook/addon-docs@npm:^6.4.0":
+  version: 6.4.19
+  resolution: "@storybook/addon-docs@npm:6.4.19"
+  dependencies:
+    "@babel/core": ^7.12.10
+    "@babel/generator": ^7.12.11
+    "@babel/parser": ^7.12.11
+    "@babel/plugin-transform-react-jsx": ^7.12.12
+    "@babel/preset-env": ^7.12.11
+    "@jest/transform": ^26.6.2
+    "@mdx-js/loader": ^1.6.22
+    "@mdx-js/mdx": ^1.6.22
+    "@mdx-js/react": ^1.6.22
+    "@storybook/addons": 6.4.19
+    "@storybook/api": 6.4.19
+    "@storybook/builder-webpack4": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/components": 6.4.19
+    "@storybook/core": 6.4.19
+    "@storybook/core-events": 6.4.19
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/csf-tools": 6.4.19
+    "@storybook/node-logger": 6.4.19
+    "@storybook/postinstall": 6.4.19
+    "@storybook/preview-web": 6.4.19
+    "@storybook/source-loader": 6.4.19
+    "@storybook/store": 6.4.19
+    "@storybook/theming": 6.4.19
+    acorn: ^7.4.1
+    acorn-jsx: ^5.3.1
+    acorn-walk: ^7.2.0
+    core-js: ^3.8.2
+    doctrine: ^3.0.0
+    escodegen: ^2.0.0
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    html-tags: ^3.1.0
+    js-string-escape: ^1.0.1
+    loader-utils: ^2.0.0
+    lodash: ^4.17.21
+    nanoid: ^3.1.23
+    p-limit: ^3.1.0
+    prettier: ">=2.2.1 <=2.3.0"
+    prop-types: ^15.7.2
+    react-element-to-jsx-string: ^14.3.4
+    regenerator-runtime: ^0.13.7
+    remark-external-links: ^8.0.0
+    remark-slug: ^6.0.0
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    "@storybook/angular": 6.4.19
+    "@storybook/html": 6.4.19
+    "@storybook/react": 6.4.19
+    "@storybook/vue": 6.4.19
+    "@storybook/vue3": 6.4.19
+    "@storybook/web-components": 6.4.19
+    lit: ^2.0.0
+    lit-html: ^1.4.1 || ^2.0.0
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+    svelte: ^3.31.2
+    sveltedoc-parser: ^4.1.0
+    vue: ^2.6.10 || ^3.0.0
+    webpack: "*"
+  peerDependenciesMeta:
+    "@storybook/angular":
+      optional: true
+    "@storybook/html":
+      optional: true
+    "@storybook/react":
+      optional: true
+    "@storybook/vue":
+      optional: true
+    "@storybook/vue3":
+      optional: true
+    "@storybook/web-components":
+      optional: true
+    lit:
+      optional: true
+    lit-html:
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+    svelte:
+      optional: true
+    sveltedoc-parser:
+      optional: true
+    vue:
+      optional: true
+    webpack:
+      optional: true
+  checksum: c2c99f3c55915960599142887870a98c7d1119d03d61f1e187dc245bfd878bc048d6189ffbca8187517d10797d655d3c44964581436afca9cf76259d3d0b1d27
   languageName: node
   linkType: hard
 
 "@storybook/addon-essentials@npm:^6.4.0":
-  version: 6.4.3
-  resolution: "@storybook/addon-essentials@npm:6.4.3"
+  version: 6.4.19
+  resolution: "@storybook/addon-essentials@npm:6.4.19"
   dependencies:
-    "@storybook/addon-actions": 6.4.3
-    "@storybook/addon-backgrounds": 6.4.3
-    "@storybook/addon-controls": 6.4.3
-    "@storybook/addon-docs": 6.4.3
-    "@storybook/addon-measure": 6.4.3
-    "@storybook/addon-outline": 6.4.3
-    "@storybook/addon-toolbars": 6.4.3
-    "@storybook/addon-viewport": 6.4.3
-    "@storybook/addons": 6.4.3
-    "@storybook/api": 6.4.3
-    "@storybook/node-logger": 6.4.3
+    "@storybook/addon-actions": 6.4.19
+    "@storybook/addon-backgrounds": 6.4.19
+    "@storybook/addon-controls": 6.4.19
+    "@storybook/addon-docs": 6.4.19
+    "@storybook/addon-measure": 6.4.19
+    "@storybook/addon-outline": 6.4.19
+    "@storybook/addon-toolbars": 6.4.19
+    "@storybook/addon-viewport": 6.4.19
+    "@storybook/addons": 6.4.19
+    "@storybook/api": 6.4.19
+    "@storybook/node-logger": 6.4.19
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
   peerDependencies:
     "@babel/core": ^7.9.6
-    "@storybook/vue": 6.4.3
-    "@storybook/web-components": 6.4.3
+    "@storybook/vue": 6.4.19
+    "@storybook/web-components": 6.4.19
     babel-loader: ^8.0.0
     lit-html: ^1.4.1 || ^2.0.0-rc.3
     react: ^16.8.0 || ^17.0.0
@@ -2490,19 +2702,63 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 2772174f775e746e4fb06e57e530d964cbebfedd0dd5ba5b96d2e3933f99374d91ea156eaa566d0b0f343e678b378150727e371bb97af04e2a7fd069e84eec3b
+  checksum: ad5b41e82ccbc564230ace6c17c1d7f9f8056d9846f123379b0a42d70c6ed5e7fa3ff57fee7aaaa65557dad59e90573faacf5a08d9a64ac4fd10772dcba5be2b
   languageName: node
   linkType: hard
 
-"@storybook/addon-links@npm:^6.4.0":
-  version: 6.4.3
-  resolution: "@storybook/addon-links@npm:6.4.3"
+"@storybook/addon-essentials@npm:^6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/addon-essentials@npm:6.4.14"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@storybook/addon-actions": 6.4.14
+    "@storybook/addon-backgrounds": 6.4.14
+    "@storybook/addon-controls": 6.4.14
+    "@storybook/addon-docs": 6.4.14
+    "@storybook/addon-measure": 6.4.14
+    "@storybook/addon-outline": 6.4.14
+    "@storybook/addon-toolbars": 6.4.14
+    "@storybook/addon-viewport": 6.4.14
+    "@storybook/addons": 6.4.14
+    "@storybook/api": 6.4.14
+    "@storybook/node-logger": 6.4.14
+    core-js: ^3.8.2
+    regenerator-runtime: ^0.13.7
+    ts-dedent: ^2.0.0
+  peerDependencies:
+    "@babel/core": ^7.9.6
+    "@storybook/vue": 6.4.14
+    "@storybook/web-components": 6.4.14
+    babel-loader: ^8.0.0
+    lit-html: ^1.4.1 || ^2.0.0-rc.3
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+    webpack: "*"
+  peerDependenciesMeta:
+    "@storybook/vue":
+      optional: true
+    "@storybook/web-components":
+      optional: true
+    lit-html:
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+    webpack:
+      optional: true
+  checksum: a2bb24c44a6b15b535f60889e06ed35224d4b357d4b4c257c68df91453ba8134b73571a9e87ff5ec1c054726ac104d89cab7a2e82a7000fa5a615cb2f5ace092
+  languageName: node
+  linkType: hard
+
+"@storybook/addon-links@npm:^6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/addon-links@npm:6.4.14"
+  dependencies:
+    "@storybook/addons": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/core-events": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/router": 6.4.3
+    "@storybook/router": 6.4.14
     "@types/qs": ^6.9.5
     core-js: ^3.8.2
     global: ^4.4.0
@@ -2518,19 +2774,19 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 57c078b0bebbf20338c2fb29ba39d9fc17546d3098eb3fe76fa426c71d196470c709b2caf29388036c55b814f9acbc2fb8854753771e810254a6acaf8eeff1be
+  checksum: fca8bf7c0ba361a1e809633a7c1e1368086de1aaf460b6074b8475da8eae7052a278fd5581fe573a95cfc3f57605d2fb6c303f6763593597df620e58971a44df
   languageName: node
   linkType: hard
 
-"@storybook/addon-measure@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/addon-measure@npm:6.4.3"
+"@storybook/addon-measure@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/addon-measure@npm:6.4.14"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/api": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/components": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@storybook/addons": 6.4.14
+    "@storybook/api": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/components": 6.4.14
+    "@storybook/core-events": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -2542,19 +2798,43 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 967a46d38aa87cf4a7f7607b32571e8357bd205e56b6a54fb3fab616617a9165729714b22f9c3dd769fcfd82d823ed494cba13545b3bd4d29f03c71d1df455e3
+  checksum: 70d20ed9bad57df920ca3a135f2c0b8a11777fa85f23bc4d762632cbd5568206540a4e7c836091138a565bf34c6c5a3e3e06f65c0a68e70ec9d524cebed3164f
   languageName: node
   linkType: hard
 
-"@storybook/addon-outline@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/addon-outline@npm:6.4.3"
+"@storybook/addon-measure@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/addon-measure@npm:6.4.19"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/api": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/components": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@storybook/addons": 6.4.19
+    "@storybook/api": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/components": 6.4.19
+    "@storybook/core-events": 6.4.19
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    core-js: ^3.8.2
+    global: ^4.4.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: bc9ff0cdc54d085027b02a2c1894c22900db6ddbe79b6e5d01de82ae0605fe95dca6a9bb2a100853fea242c473db47f8b2eb1e8daae55157a4383a64840358f4
+  languageName: node
+  linkType: hard
+
+"@storybook/addon-outline@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/addon-outline@npm:6.4.14"
+  dependencies:
+    "@storybook/addons": 6.4.14
+    "@storybook/api": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/components": 6.4.14
+    "@storybook/core-events": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -2568,7 +2848,33 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: fa4418b72faf17662eccc513e169275443c6461c1e2be84efaf18a862faa14f483a72c03e49eba2af1340e02be218135f81124129b0ccdd7c8a7039f0bb5489d
+  checksum: ea3eb36d597e25ebf73f52f1dbacbb026bd9adb9f98796a0aede804b1eac8d580fdf705414b435fd31835c643ece23debeaae8871e39b31fb5c80d69634416c9
+  languageName: node
+  linkType: hard
+
+"@storybook/addon-outline@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/addon-outline@npm:6.4.19"
+  dependencies:
+    "@storybook/addons": 6.4.19
+    "@storybook/api": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/components": 6.4.19
+    "@storybook/core-events": 6.4.19
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    core-js: ^3.8.2
+    global: ^4.4.0
+    regenerator-runtime: ^0.13.7
+    ts-dedent: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: c8f6fcae9ca03717b1b767a7504c49cf9a0c5ae81d5489e960544fc1a986eeac4e183cceecbb5e6200aeec2e39b3821caf8e5ec64acda381dd6ffb1b8e41dd09
   languageName: node
   linkType: hard
 
@@ -2601,14 +2907,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-toolbars@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/addon-toolbars@npm:6.4.3"
+"@storybook/addon-toolbars@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/addon-toolbars@npm:6.4.14"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/api": 6.4.3
-    "@storybook/components": 6.4.3
-    "@storybook/theming": 6.4.3
+    "@storybook/addons": 6.4.14
+    "@storybook/api": 6.4.14
+    "@storybook/components": 6.4.14
+    "@storybook/theming": 6.4.14
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
   peerDependencies:
@@ -2619,20 +2925,42 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: d629950bff90825829e55554f691f45ce6c24e38da9e3af0d43d6c921c3c4a97e55751405c19f73f79251c113fee14c613347aee4b4b7bea686915feb5821e2c
+  checksum: 8119a16c9621a6cc8d81a1c269134341d6b0c68478e3639cd1e7738075cd7665743c814bfcdd2997780b1c621bc508813834bae73763ade124f6898f4b23bd72
   languageName: node
   linkType: hard
 
-"@storybook/addon-viewport@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/addon-viewport@npm:6.4.3"
+"@storybook/addon-toolbars@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/addon-toolbars@npm:6.4.19"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/api": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/components": 6.4.3
-    "@storybook/core-events": 6.4.3
-    "@storybook/theming": 6.4.3
+    "@storybook/addons": 6.4.19
+    "@storybook/api": 6.4.19
+    "@storybook/components": 6.4.19
+    "@storybook/theming": 6.4.19
+    core-js: ^3.8.2
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 32e8e1ff57c55a5db57efc3703331dc11472abd86c8cfac28c622465ea3f76bf819c80623f10166d034cf9e1db71cdf1db4d069a4cec6124f60514a8c712d210
+  languageName: node
+  linkType: hard
+
+"@storybook/addon-viewport@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/addon-viewport@npm:6.4.14"
+  dependencies:
+    "@storybook/addons": 6.4.14
+    "@storybook/api": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/components": 6.4.14
+    "@storybook/core-events": 6.4.14
+    "@storybook/theming": 6.4.14
     core-js: ^3.8.2
     global: ^4.4.0
     memoizerific: ^1.11.3
@@ -2646,7 +2974,39 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: b74a1100691afa4923d023f9f73c20a73f21ef8ea4e6732a6a60cb205a35915a592e4b705555c50bee91ff3a0a40f3a5235d6d79da0e7e9adcc3412d576225ca
+  checksum: f9c72fd0976ca98d86a1afb81f19a0ca311a6294a880bcc64f2400157c9273e19295a58c86465caaffb9c730d4feea6936c60f3db731ee1710befd5996424c46
+  languageName: node
+  linkType: hard
+
+"@storybook/addon-viewport@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/addon-viewport@npm:6.4.19"
+  dependencies:
+    "@storybook/addons": 6.4.19
+    "@storybook/api": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/components": 6.4.19
+    "@storybook/core-events": 6.4.19
+    "@storybook/theming": 6.4.19
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    memoizerific: ^1.11.3
+    prop-types: ^15.7.2
+    regenerator-runtime: ^0.13.7
+    store2: ^2.12.0
+    telejson: ^5.3.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 4d99d4596ed04aba67394b138e546cbd5996a1645e41c411e3068be908028200dcfd9aa0a18e6fcbde134e3fc10b0d92d337c21da4451d67532cf6fc3739b4a4
   languageName: node
   linkType: hard
 
@@ -2670,17 +3030,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addons@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/addons@npm:6.4.3"
+"@storybook/addons@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/addons@npm:6.4.14"
   dependencies:
-    "@storybook/api": 6.4.3
-    "@storybook/channels": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@storybook/api": 6.4.14
+    "@storybook/channels": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/core-events": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/router": 6.4.3
-    "@storybook/theming": 6.4.3
+    "@storybook/router": 6.4.14
+    "@storybook/theming": 6.4.14
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -2688,7 +3048,29 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 32b9fecdc1dfee712260b7aa8272db8d3d4ecd93bb68bb210b25413afc9356e32fd683052e4587f3a724729bc43a0c0bfaa0c2cc43614204a92b8e5f3590ba2b
+  checksum: a94de702b9d20e38ad5a1b563d85a879c4e1f870f3d760d7bc4de149ba5ec060e901ef3ac8d252bc4600fb70d20aa64664f27418f29322905e20c037e87a9da2
+  languageName: node
+  linkType: hard
+
+"@storybook/addons@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/addons@npm:6.4.19"
+  dependencies:
+    "@storybook/api": 6.4.19
+    "@storybook/channels": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/core-events": 6.4.19
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/router": 6.4.19
+    "@storybook/theming": 6.4.19
+    "@types/webpack-env": ^1.16.0
+    core-js: ^3.8.2
+    global: ^4.4.0
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 867e93a83c1145443693a4af04a83b597afde2663d779cf81db53cc1f77d53da1d4255bd7b403a19685cd0df739c4863eed31f2ef2f1a5c9ca4ae025e191240a
   languageName: node
   linkType: hard
 
@@ -2723,21 +3105,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/api@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/api@npm:6.4.3"
+"@storybook/api@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/api@npm:6.4.14"
   dependencies:
-    "@storybook/channels": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@storybook/channels": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/core-events": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/router": 6.4.3
+    "@storybook/router": 6.4.14
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.4.3
+    "@storybook/theming": 6.4.14
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     memoizerific: ^1.11.3
     regenerator-runtime: ^0.13.7
     store2: ^2.12.0
@@ -2747,13 +3129,41 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: e48ec46b280bac9f3c5d31d94b2cbdad9381fcdf9e5866ecab780af5ca0264ed9b9ddd598efaa1de6b7ab60feab07eb3388758af078ddae7bd386387327d3566
+  checksum: 51e1bec50259b0e3ae9ff96f4e8d5c340e22cff25837c50bf6ff0405c1bddf48998aaa8cdaa3810b41ff0052fda2ed8c17bd28fb77cd7c568b283224baac0be9
   languageName: node
   linkType: hard
 
-"@storybook/builder-webpack4@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/builder-webpack4@npm:6.4.3"
+"@storybook/api@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/api@npm:6.4.19"
+  dependencies:
+    "@storybook/channels": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/core-events": 6.4.19
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/router": 6.4.19
+    "@storybook/semver": ^7.3.2
+    "@storybook/theming": 6.4.19
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    regenerator-runtime: ^0.13.7
+    store2: ^2.12.0
+    telejson: ^5.3.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 305c413ee81f98c0064bbefdd88ee61f4ce0af18465412d7e771ba7af9825c4aa134d827d21f5e7e0dafbb41fafd5a68c65df29525de8bd382b24a960b78e97a
+  languageName: node
+  linkType: hard
+
+"@storybook/builder-webpack4@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/builder-webpack4@npm:6.4.14"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -2776,22 +3186,22 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.4.3
-    "@storybook/api": 6.4.3
-    "@storybook/channel-postmessage": 6.4.3
-    "@storybook/channels": 6.4.3
-    "@storybook/client-api": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/components": 6.4.3
-    "@storybook/core-common": 6.4.3
-    "@storybook/core-events": 6.4.3
-    "@storybook/node-logger": 6.4.3
-    "@storybook/preview-web": 6.4.3
-    "@storybook/router": 6.4.3
+    "@storybook/addons": 6.4.14
+    "@storybook/api": 6.4.14
+    "@storybook/channel-postmessage": 6.4.14
+    "@storybook/channels": 6.4.14
+    "@storybook/client-api": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/components": 6.4.14
+    "@storybook/core-common": 6.4.14
+    "@storybook/core-events": 6.4.14
+    "@storybook/node-logger": 6.4.14
+    "@storybook/preview-web": 6.4.14
+    "@storybook/router": 6.4.14
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.3
-    "@storybook/theming": 6.4.3
-    "@storybook/ui": 6.4.3
+    "@storybook/store": 6.4.14
+    "@storybook/theming": 6.4.14
+    "@storybook/ui": 6.4.14
     "@types/node": ^14.0.10
     "@types/webpack": ^4.41.26
     autoprefixer: ^9.8.6
@@ -2813,7 +3223,6 @@ __metadata:
     postcss-flexbugs-fixes: ^4.2.1
     postcss-loader: ^4.2.0
     raw-loader: ^4.0.2
-    react-dev-utils: ^11.0.4
     stable: ^0.1.8
     style-loader: ^1.3.0
     terser-webpack-plugin: ^4.2.3
@@ -2831,35 +3240,146 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 42062a4c79b10d0761a1157195fc812f682c467b446b9b78aa37cb1baaa9c35f511299fefae5ce3b51bc042f182bf95904991866273fde61a2d73605dd7c7726
+  checksum: d38ff27cee11a348c6c3d4a1f75cec22f52c777fb675882635e78d26854505de5c440f45b3f4cb0795c931ad67445d2e5dc469dda3f7f65749a1d6ac81de2661
   languageName: node
   linkType: hard
 
-"@storybook/channel-postmessage@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/channel-postmessage@npm:6.4.3"
+"@storybook/builder-webpack4@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/builder-webpack4@npm:6.4.19"
   dependencies:
-    "@storybook/channels": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@babel/core": ^7.12.10
+    "@babel/plugin-proposal-class-properties": ^7.12.1
+    "@babel/plugin-proposal-decorators": ^7.12.12
+    "@babel/plugin-proposal-export-default-from": ^7.12.1
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.12.1
+    "@babel/plugin-proposal-object-rest-spread": ^7.12.1
+    "@babel/plugin-proposal-optional-chaining": ^7.12.7
+    "@babel/plugin-proposal-private-methods": ^7.12.1
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/plugin-transform-arrow-functions": ^7.12.1
+    "@babel/plugin-transform-block-scoping": ^7.12.12
+    "@babel/plugin-transform-classes": ^7.12.1
+    "@babel/plugin-transform-destructuring": ^7.12.1
+    "@babel/plugin-transform-for-of": ^7.12.1
+    "@babel/plugin-transform-parameters": ^7.12.1
+    "@babel/plugin-transform-shorthand-properties": ^7.12.1
+    "@babel/plugin-transform-spread": ^7.12.1
+    "@babel/plugin-transform-template-literals": ^7.12.1
+    "@babel/preset-env": ^7.12.11
+    "@babel/preset-react": ^7.12.10
+    "@babel/preset-typescript": ^7.12.7
+    "@storybook/addons": 6.4.19
+    "@storybook/api": 6.4.19
+    "@storybook/channel-postmessage": 6.4.19
+    "@storybook/channels": 6.4.19
+    "@storybook/client-api": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/components": 6.4.19
+    "@storybook/core-common": 6.4.19
+    "@storybook/core-events": 6.4.19
+    "@storybook/node-logger": 6.4.19
+    "@storybook/preview-web": 6.4.19
+    "@storybook/router": 6.4.19
+    "@storybook/semver": ^7.3.2
+    "@storybook/store": 6.4.19
+    "@storybook/theming": 6.4.19
+    "@storybook/ui": 6.4.19
+    "@types/node": ^14.0.10
+    "@types/webpack": ^4.41.26
+    autoprefixer: ^9.8.6
+    babel-loader: ^8.0.0
+    babel-plugin-macros: ^2.8.0
+    babel-plugin-polyfill-corejs3: ^0.1.0
+    case-sensitive-paths-webpack-plugin: ^2.3.0
+    core-js: ^3.8.2
+    css-loader: ^3.6.0
+    file-loader: ^6.2.0
+    find-up: ^5.0.0
+    fork-ts-checker-webpack-plugin: ^4.1.6
+    glob: ^7.1.6
+    glob-promise: ^3.4.0
+    global: ^4.4.0
+    html-webpack-plugin: ^4.0.0
+    pnp-webpack-plugin: 1.6.4
+    postcss: ^7.0.36
+    postcss-flexbugs-fixes: ^4.2.1
+    postcss-loader: ^4.2.0
+    raw-loader: ^4.0.2
+    stable: ^0.1.8
+    style-loader: ^1.3.0
+    terser-webpack-plugin: ^4.2.3
+    ts-dedent: ^2.0.0
+    url-loader: ^4.1.1
+    util-deprecate: ^1.0.2
+    webpack: 4
+    webpack-dev-middleware: ^3.7.3
+    webpack-filter-warnings-plugin: ^1.2.1
+    webpack-hot-middleware: ^2.25.1
+    webpack-virtual-modules: ^0.2.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 6117b3063e589b1ca92b03cb16fb6258d97aef8828012390bcd4566e813ea8b03b042ba0f9ccf69efa0c21102a0b843dcca544784c25cc8b09103e32991160ad
+  languageName: node
+  linkType: hard
+
+"@storybook/channel-postmessage@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/channel-postmessage@npm:6.4.14"
+  dependencies:
+    "@storybook/channels": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/core-events": 6.4.14
     core-js: ^3.8.2
     global: ^4.4.0
     qs: ^6.10.0
     telejson: ^5.3.2
-  checksum: 3c4424a658982ea54a767e5425684b8d0e9e410ef33a8a9269ddbe260dc5270491ae9c1fac88e6e677e09f592b2035bc4e54d4905e3c84e51035b527488d0c65
+  checksum: b6010e8616892fee339921a72f595f40823e40912deb597ffe9fdb0b7ff6e929a712393f217ad3b800ba7f4c763de6209401777f724b7ce5135180abfacdc7dc
   languageName: node
   linkType: hard
 
-"@storybook/channel-websocket@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/channel-websocket@npm:6.4.3"
+"@storybook/channel-postmessage@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/channel-postmessage@npm:6.4.19"
   dependencies:
-    "@storybook/channels": 6.4.3
-    "@storybook/client-logger": 6.4.3
+    "@storybook/channels": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/core-events": 6.4.19
+    core-js: ^3.8.2
+    global: ^4.4.0
+    qs: ^6.10.0
+    telejson: ^5.3.2
+  checksum: 1cb783c13209859d4f4a43e79b348aef749842e323f48f8ce49fe67f7a9aecdda7b4b1722c18ac8c186ca55fccc29fe8426e303d8f2486aeb0a4db04836c981b
+  languageName: node
+  linkType: hard
+
+"@storybook/channel-websocket@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/channel-websocket@npm:6.4.14"
+  dependencies:
+    "@storybook/channels": 6.4.14
+    "@storybook/client-logger": 6.4.14
     core-js: ^3.8.2
     global: ^4.4.0
     telejson: ^5.3.2
-  checksum: 4d708ad35b7fd4acaca563c13b23c735f29fd2dad72ef1307e087d3797ca0462d5558183376dbeb9ce9d61b55b983c700a0ce0ec2072dce1fc4eb89b2dd3338b
+  checksum: 2a3363d7312cd9d11fc9ad7da373d9b41c14a262b9dc5f6fa23f9b0c446583c19bb662e65083dd46a9229a6497019b556e2ca8567b24f76cccb761c8cab23726
+  languageName: node
+  linkType: hard
+
+"@storybook/channel-websocket@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/channel-websocket@npm:6.4.19"
+  dependencies:
+    "@storybook/channels": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    core-js: ^3.8.2
+    global: ^4.4.0
+    telejson: ^5.3.2
+  checksum: 2a69258308c3701b35ce3a3b6a216ec8d3c7d28bc875757677f6b284fd1da75849565d92846a509cafd8ce8f75513c5495d85f44c342c67e0887c19154862867
   languageName: node
   linkType: hard
 
@@ -2874,34 +3394,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/channels@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/channels@npm:6.4.3"
+"@storybook/channels@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/channels@npm:6.4.14"
   dependencies:
     core-js: ^3.8.2
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
-  checksum: 4addffe2b32cc5cbc4106f4332d2045fc1611c01bfaa89c5a22706f8c006a0217a4fd00ab26125c0aa27459dc87ef7de0f20619ba895036ac0dead1fbec9401a
+  checksum: 614aa84dca406e024a42606fd01f1290dc79042641a2feb4e74eb5e2d8ac28271093c78cc189207bae6ee6cf90c0024f1f3846c8cd6c4b360bf927e13afc0b73
   languageName: node
   linkType: hard
 
-"@storybook/client-api@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/client-api@npm:6.4.3"
+"@storybook/channels@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/channels@npm:6.4.19"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/channel-postmessage": 6.4.3
-    "@storybook/channels": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/core-events": 6.4.3
+    core-js: ^3.8.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  checksum: 034c26467cb6dad9b893ee1655a5a550b588fa96d3306d38a775e8fb5b3b9e9da22da2111fc315c0c85a8aaf31f417242b1bd2238e1df84a56d6cef22fac9f64
+  languageName: node
+  linkType: hard
+
+"@storybook/client-api@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/client-api@npm:6.4.14"
+  dependencies:
+    "@storybook/addons": 6.4.14
+    "@storybook/channel-postmessage": 6.4.14
+    "@storybook/channels": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/core-events": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/store": 6.4.3
+    "@storybook/store": 6.4.14
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     memoizerific: ^1.11.3
     qs: ^6.10.0
     regenerator-runtime: ^0.13.7
@@ -2912,7 +3443,38 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: f95857fde059c5d1cac23051ecf9ad78b3002183bd657399d5684ed7964d5c76250ccc34737cd17991cc2503001b17a5388bed78f2edcf69aa050633c15f434e
+  checksum: a15f7f5267cf2bc85fc00e71340e0fe3499a74f937cc0b1d1336f4ac18768d1175dc876146650b02deb6f1b4f386826794d3b0f7fc52fc03450879ad07eea15a
+  languageName: node
+  linkType: hard
+
+"@storybook/client-api@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/client-api@npm:6.4.19"
+  dependencies:
+    "@storybook/addons": 6.4.19
+    "@storybook/channel-postmessage": 6.4.19
+    "@storybook/channels": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/core-events": 6.4.19
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/store": 6.4.19
+    "@types/qs": ^6.9.5
+    "@types/webpack-env": ^1.16.0
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+    regenerator-runtime: ^0.13.7
+    store2: ^2.12.0
+    synchronous-promise: ^2.0.15
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 1e94a98d99d4011a1b61a77ee928c90c2d7dfedb7e692c83a571158a8bae74cbe478a2d3a41623ecec69b28f34da21869dd3f25517425d5fce6117367048ebaf
   languageName: node
   linkType: hard
 
@@ -2926,24 +3488,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/client-logger@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/client-logger@npm:6.4.3"
+"@storybook/client-logger@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/client-logger@npm:6.4.14"
   dependencies:
     core-js: ^3.8.2
     global: ^4.4.0
-  checksum: 2812b08328464edcf3f94819d522a189b2fa2e31ed7eb2cb3e750ec5abf9da6efa961d6d24266a0e52922be444935c2183b9b189b4535293415c6efa563f2211
+  checksum: fbe2c3161219724932b337455d48b84bd7f33da6f0aab8d8ef4c9c5f39167118185c06fd0291ce33dddb9c2b2991fb4b80b84537ef0aa3baa9c5d1e58356af76
   languageName: node
   linkType: hard
 
-"@storybook/components@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/components@npm:6.4.3"
+"@storybook/client-logger@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/client-logger@npm:6.4.19"
+  dependencies:
+    core-js: ^3.8.2
+    global: ^4.4.0
+  checksum: 06eb583d05c951d526c7a7e2de461a693d2b491fc35f35a716762e031b3978d4d479c9dcdd81c855d3051318ee4fbd43fe0718b66d560b9d97e28bde1ce7378c
+  languageName: node
+  linkType: hard
+
+"@storybook/components@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/components@npm:6.4.14"
   dependencies:
     "@popperjs/core": ^2.6.0
-    "@storybook/client-logger": 6.4.3
+    "@storybook/client-logger": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.3
+    "@storybook/theming": 6.4.14
     "@types/color-convert": ^2.0.0
     "@types/overlayscrollbars": ^1.12.0
     "@types/react-syntax-highlighter": 11.0.5
@@ -2951,7 +3523,7 @@ __metadata:
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     markdown-to-jsx: ^7.1.3
     memoizerific: ^1.11.3
     overlayscrollbars: ^1.13.1
@@ -2967,29 +3539,64 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: eb3762c6c7c39ca0985e28fd794c61307d5fa5f261b4e1d695c9dfbf5b68c1f10b523e9356456c65fc0f5efa64ae770e833a9d0edcda934c9f1f00d51b2125b1
+  checksum: 50fbcb9854dcb785a280a5e829997b32d8500c16adb2a3c8ebaeb5c6f897f9e72281b7da8d931b589e80f83ec86bf064458f4c7d96ea6d61f97422f4e10d9a64
   languageName: node
   linkType: hard
 
-"@storybook/core-client@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/core-client@npm:6.4.3"
+"@storybook/components@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/components@npm:6.4.19"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/channel-postmessage": 6.4.3
-    "@storybook/channel-websocket": 6.4.3
-    "@storybook/client-api": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@popperjs/core": ^2.6.0
+    "@storybook/client-logger": 6.4.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/preview-web": 6.4.3
-    "@storybook/store": 6.4.3
-    "@storybook/ui": 6.4.3
+    "@storybook/theming": 6.4.19
+    "@types/color-convert": ^2.0.0
+    "@types/overlayscrollbars": ^1.12.0
+    "@types/react-syntax-highlighter": 11.0.5
+    color-convert: ^2.0.1
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    markdown-to-jsx: ^7.1.3
+    memoizerific: ^1.11.3
+    overlayscrollbars: ^1.13.1
+    polished: ^4.0.5
+    prop-types: ^15.7.2
+    react-colorful: ^5.1.2
+    react-popper-tooltip: ^3.1.1
+    react-syntax-highlighter: ^13.5.3
+    react-textarea-autosize: ^8.3.0
+    regenerator-runtime: ^0.13.7
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 200ea23620f191b571bbb182109716eb00405eeb7deb16e61fe38434d1c12b8ec3a2edc209ac128ead3dd46c2e03146bf84b63f5f8707b5dd0aa715624b97f52
+  languageName: node
+  linkType: hard
+
+"@storybook/core-client@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/core-client@npm:6.4.14"
+  dependencies:
+    "@storybook/addons": 6.4.14
+    "@storybook/channel-postmessage": 6.4.14
+    "@storybook/channel-websocket": 6.4.14
+    "@storybook/client-api": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/core-events": 6.4.14
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/preview-web": 6.4.14
+    "@storybook/store": 6.4.14
+    "@storybook/ui": 6.4.14
     airbnb-js-shims: ^2.2.1
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     qs: ^6.10.0
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
@@ -3002,13 +3609,48 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: c64e4027353f216db5902a9c24ba43118e4f4615971c802fa31f275df356ba83f25f30352f1155ce7a695441e65dd65a2998d557cb76939900e8823cc0f96c1c
+  checksum: a48a727be20e5bb0f085c41cb19503c94b37ca39a9b8501838de1e3db1cf480c35bfa88d4f53565542a159825850cc1577917e295064cde24543de09fa47209f
   languageName: node
   linkType: hard
 
-"@storybook/core-common@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/core-common@npm:6.4.3"
+"@storybook/core-client@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/core-client@npm:6.4.19"
+  dependencies:
+    "@storybook/addons": 6.4.19
+    "@storybook/channel-postmessage": 6.4.19
+    "@storybook/channel-websocket": 6.4.19
+    "@storybook/client-api": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/core-events": 6.4.19
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/preview-web": 6.4.19
+    "@storybook/store": 6.4.19
+    "@storybook/ui": 6.4.19
+    airbnb-js-shims: ^2.2.1
+    ansi-to-html: ^0.6.11
+    core-js: ^3.8.2
+    global: ^4.4.0
+    lodash: ^4.17.21
+    qs: ^6.10.0
+    regenerator-runtime: ^0.13.7
+    ts-dedent: ^2.0.0
+    unfetch: ^4.2.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+    webpack: "*"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: f288a68f09bef1a88a72dcff8c8190ee8f75f2d93dd1404e33d62cd2d8a34d937553456349f0390c9f14442d5a77eb8c547ff9127d315f2db1b339ed7a841139
+  languageName: node
+  linkType: hard
+
+"@storybook/core-common@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/core-common@npm:6.4.14"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -3031,7 +3673,7 @@ __metadata:
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
     "@babel/register": ^7.12.1
-    "@storybook/node-logger": 6.4.3
+    "@storybook/node-logger": 6.4.14
     "@storybook/semver": ^7.3.2
     "@types/node": ^14.0.10
     "@types/pretty-hrtime": ^1.0.0
@@ -3065,7 +3707,70 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 36583e493f9b37eeea8ee762c6a202a2905efa46df014eacad32dd88f54061906fca68f066e71a26a9c163bb563eb0736484d45c7122e766b304a091780d4452
+  checksum: 1afa456fd4b0ca9cd1e1811deb4cac390e350a9fa67c422d5d2e4f439439d86eed038f1245dbdbe0850a2b59d0c124c1fcf7f5025c5c00f4e3ec97ee54ca7ada
+  languageName: node
+  linkType: hard
+
+"@storybook/core-common@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/core-common@npm:6.4.19"
+  dependencies:
+    "@babel/core": ^7.12.10
+    "@babel/plugin-proposal-class-properties": ^7.12.1
+    "@babel/plugin-proposal-decorators": ^7.12.12
+    "@babel/plugin-proposal-export-default-from": ^7.12.1
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.12.1
+    "@babel/plugin-proposal-object-rest-spread": ^7.12.1
+    "@babel/plugin-proposal-optional-chaining": ^7.12.7
+    "@babel/plugin-proposal-private-methods": ^7.12.1
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/plugin-transform-arrow-functions": ^7.12.1
+    "@babel/plugin-transform-block-scoping": ^7.12.12
+    "@babel/plugin-transform-classes": ^7.12.1
+    "@babel/plugin-transform-destructuring": ^7.12.1
+    "@babel/plugin-transform-for-of": ^7.12.1
+    "@babel/plugin-transform-parameters": ^7.12.1
+    "@babel/plugin-transform-shorthand-properties": ^7.12.1
+    "@babel/plugin-transform-spread": ^7.12.1
+    "@babel/preset-env": ^7.12.11
+    "@babel/preset-react": ^7.12.10
+    "@babel/preset-typescript": ^7.12.7
+    "@babel/register": ^7.12.1
+    "@storybook/node-logger": 6.4.19
+    "@storybook/semver": ^7.3.2
+    "@types/node": ^14.0.10
+    "@types/pretty-hrtime": ^1.0.0
+    babel-loader: ^8.0.0
+    babel-plugin-macros: ^3.0.1
+    babel-plugin-polyfill-corejs3: ^0.1.0
+    chalk: ^4.1.0
+    core-js: ^3.8.2
+    express: ^4.17.1
+    file-system-cache: ^1.0.5
+    find-up: ^5.0.0
+    fork-ts-checker-webpack-plugin: ^6.0.4
+    fs-extra: ^9.0.1
+    glob: ^7.1.6
+    handlebars: ^4.7.7
+    interpret: ^2.2.0
+    json5: ^2.1.3
+    lazy-universal-dotenv: ^3.0.1
+    picomatch: ^2.3.0
+    pkg-dir: ^5.0.0
+    pretty-hrtime: ^1.0.3
+    resolve-from: ^5.0.0
+    slash: ^3.0.0
+    telejson: ^5.3.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+    webpack: 4
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 3f10064014cd6aa429f5bacc3e6fb741d47b670dc2e4c60dac20251786246f2c485abb226eca6d32c6ff382e14d1758b175c160115c34fb3b647067bb6653283
   languageName: node
   linkType: hard
 
@@ -3078,30 +3783,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/core-events@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/core-events@npm:6.4.3"
+"@storybook/core-events@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/core-events@npm:6.4.14"
   dependencies:
     core-js: ^3.8.2
-  checksum: e893271063158dbc03413e7bd4f070f6a4a13c89c865cf8ccef712de1cb362af9d3f63571a73ff3368a8154789951d65e8d5a80415634639c61662e5b766f0b7
+  checksum: b4e050129aa53c1001caf828c4a303df155f662168e6e9971d19bf7892ab79454d24b14199c423bf1f756369f24f042513dee618b13055e2e0cb4dfb87ad13e6
   languageName: node
   linkType: hard
 
-"@storybook/core-server@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/core-server@npm:6.4.3"
+"@storybook/core-events@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/core-events@npm:6.4.19"
+  dependencies:
+    core-js: ^3.8.2
+  checksum: a10620f3f6b6e0dd22951c3c2287482bdb3e53c98b4b482f142aa2e979ae993a9ee626686a7320f97ce2fe82dcb5afec037346abfda4f33c2f612b1cd83c74a2
+  languageName: node
+  linkType: hard
+
+"@storybook/core-server@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/core-server@npm:6.4.14"
   dependencies:
     "@discoveryjs/json-ext": ^0.5.3
-    "@storybook/builder-webpack4": 6.4.3
-    "@storybook/core-client": 6.4.3
-    "@storybook/core-common": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@storybook/builder-webpack4": 6.4.14
+    "@storybook/core-client": 6.4.14
+    "@storybook/core-common": 6.4.14
+    "@storybook/core-events": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/csf-tools": 6.4.3
-    "@storybook/manager-webpack4": 6.4.3
-    "@storybook/node-logger": 6.4.3
+    "@storybook/csf-tools": 6.4.14
+    "@storybook/manager-webpack4": 6.4.14
+    "@storybook/node-logger": 6.4.14
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.3
+    "@storybook/store": 6.4.14
     "@types/node": ^14.0.10
     "@types/node-fetch": ^2.5.7
     "@types/pretty-hrtime": ^1.0.0
@@ -3109,7 +3823,7 @@ __metadata:
     better-opn: ^2.1.1
     boxen: ^5.1.2
     chalk: ^4.1.0
-    cli-table3: 0.6.0
+    cli-table3: ^0.6.1
     commander: ^6.2.1
     compression: ^1.7.4
     core-js: ^3.8.2
@@ -3120,7 +3834,7 @@ __metadata:
     fs-extra: ^9.0.1
     globby: ^11.0.2
     ip: ^1.1.5
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     node-fetch: ^2.6.1
     pretty-hrtime: ^1.0.3
     prompts: ^2.4.0
@@ -3134,8 +3848,8 @@ __metadata:
     webpack: 4
     ws: ^8.2.3
   peerDependencies:
-    "@storybook/builder-webpack5": 6.4.3
-    "@storybook/manager-webpack5": 6.4.3
+    "@storybook/builder-webpack5": 6.4.14
+    "@storybook/manager-webpack5": 6.4.14
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   peerDependenciesMeta:
@@ -3145,18 +3859,80 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: c8bbaae25dd66f009716a619749372d0d1460d279aa7e1f048030546df3314658076fc3813b61b611251f88df42f1e4a8161e2e44dc6b7d6d9b9cb77e6468fb0
+  checksum: 61f635b8bbf21ad50c904aea31e943e9f67fd1cb09d46b5680cebb3723d938c46626810960da6c69fd2a00d0c8aa9e1ee5eb1ccc10bf3af36a6339deaf2fc40c
   languageName: node
   linkType: hard
 
-"@storybook/core@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/core@npm:6.4.3"
+"@storybook/core-server@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/core-server@npm:6.4.19"
   dependencies:
-    "@storybook/core-client": 6.4.3
-    "@storybook/core-server": 6.4.3
+    "@discoveryjs/json-ext": ^0.5.3
+    "@storybook/builder-webpack4": 6.4.19
+    "@storybook/core-client": 6.4.19
+    "@storybook/core-common": 6.4.19
+    "@storybook/core-events": 6.4.19
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/csf-tools": 6.4.19
+    "@storybook/manager-webpack4": 6.4.19
+    "@storybook/node-logger": 6.4.19
+    "@storybook/semver": ^7.3.2
+    "@storybook/store": 6.4.19
+    "@types/node": ^14.0.10
+    "@types/node-fetch": ^2.5.7
+    "@types/pretty-hrtime": ^1.0.0
+    "@types/webpack": ^4.41.26
+    better-opn: ^2.1.1
+    boxen: ^5.1.2
+    chalk: ^4.1.0
+    cli-table3: ^0.6.1
+    commander: ^6.2.1
+    compression: ^1.7.4
+    core-js: ^3.8.2
+    cpy: ^8.1.2
+    detect-port: ^1.3.0
+    express: ^4.17.1
+    file-system-cache: ^1.0.5
+    fs-extra: ^9.0.1
+    globby: ^11.0.2
+    ip: ^1.1.5
+    lodash: ^4.17.21
+    node-fetch: ^2.6.1
+    pretty-hrtime: ^1.0.3
+    prompts: ^2.4.0
+    regenerator-runtime: ^0.13.7
+    serve-favicon: ^2.5.0
+    slash: ^3.0.0
+    telejson: ^5.3.3
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+    watchpack: ^2.2.0
+    webpack: 4
+    ws: ^8.2.3
   peerDependencies:
-    "@storybook/builder-webpack5": 6.4.3
+    "@storybook/builder-webpack5": 6.4.19
+    "@storybook/manager-webpack5": 6.4.19
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    "@storybook/builder-webpack5":
+      optional: true
+    "@storybook/manager-webpack5":
+      optional: true
+    typescript:
+      optional: true
+  checksum: 7c601f1bbf1c837a5128abdc5e751d91c3bfb34ba80348b9dc1a434e51cca10e33fc16da7db322b6850b0e9229fb2dc3b4b02c535306cb97a9179b0bc272947f
+  languageName: node
+  linkType: hard
+
+"@storybook/core@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/core@npm:6.4.14"
+  dependencies:
+    "@storybook/core-client": 6.4.14
+    "@storybook/core-server": 6.4.14
+  peerDependencies:
+    "@storybook/builder-webpack5": 6.4.14
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
     webpack: "*"
@@ -3165,13 +3941,33 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 5e8a3b416e94e3246deac50ef22014435d6a06a43e98df18a1dc1e763b26cdaec784f6f381655efb6c82ea44c62049fb89eaeaa6351cd6cfe641607d6a88f336
+  checksum: ac19373e73529b143834f85d9bedbf93cd646fccb206591b05e400bada5631a14fd5c5566416f235d541ce1fb544441265d8c1f65e99376c3b0131357c59c642
   languageName: node
   linkType: hard
 
-"@storybook/csf-tools@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/csf-tools@npm:6.4.3"
+"@storybook/core@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/core@npm:6.4.19"
+  dependencies:
+    "@storybook/core-client": 6.4.19
+    "@storybook/core-server": 6.4.19
+  peerDependencies:
+    "@storybook/builder-webpack5": 6.4.19
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+    webpack: "*"
+  peerDependenciesMeta:
+    "@storybook/builder-webpack5":
+      optional: true
+    typescript:
+      optional: true
+  checksum: 07b510c3983a816d94f12d55c5e6b20f19f7d2419429a89bb1f787a88f325733bf761be934a796fe7a90a625a544e838f7f2e48a2750e7099a318013e19f0e19
+  languageName: node
+  linkType: hard
+
+"@storybook/csf-tools@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/csf-tools@npm:6.4.14"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/generator": ^7.12.11
@@ -3186,11 +3982,36 @@ __metadata:
     fs-extra: ^9.0.1
     global: ^4.4.0
     js-string-escape: ^1.0.1
-    lodash: ^4.17.20
-    prettier: ^2.2.1
+    lodash: ^4.17.21
+    prettier: ">=2.2.1 <=2.3.0"
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
-  checksum: 5b9a5326cd2c3bfb8f3b638b0f1266fd108b07e418f28fad6375deee095f79a191670d6e61c01223b4af86ebd711240352bebaaf6716c5f1839f44d0662ebda5
+  checksum: 448cb846ee609ad76b5bd35921779e73f79bdaf7ab1b45687bfe6f3b57b8ec3e52b77dc5a672f9693068f04a9058ec306d2a524e7bef9e58d82c234ce1403224
+  languageName: node
+  linkType: hard
+
+"@storybook/csf-tools@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/csf-tools@npm:6.4.19"
+  dependencies:
+    "@babel/core": ^7.12.10
+    "@babel/generator": ^7.12.11
+    "@babel/parser": ^7.12.11
+    "@babel/plugin-transform-react-jsx": ^7.12.12
+    "@babel/preset-env": ^7.12.11
+    "@babel/traverse": ^7.12.11
+    "@babel/types": ^7.12.11
+    "@mdx-js/mdx": ^1.6.22
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    core-js: ^3.8.2
+    fs-extra: ^9.0.1
+    global: ^4.4.0
+    js-string-escape: ^1.0.1
+    lodash: ^4.17.21
+    prettier: ">=2.2.1 <=2.3.0"
+    regenerator-runtime: ^0.13.7
+    ts-dedent: ^2.0.0
+  checksum: 33c01f8837fb001129aa28c5aefb6c46bd3f3780e73ec108545f2f87aef1041bfed1bde04578d68c6b759e19839e084052c5b3c532733ff762285f1e8040a37c
   languageName: node
   linkType: hard
 
@@ -3234,19 +4055,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/manager-webpack4@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/manager-webpack4@npm:6.4.3"
+"@storybook/manager-webpack4@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/manager-webpack4@npm:6.4.14"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-template-literals": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.4.3
-    "@storybook/core-client": 6.4.3
-    "@storybook/core-common": 6.4.3
-    "@storybook/node-logger": 6.4.3
-    "@storybook/theming": 6.4.3
-    "@storybook/ui": 6.4.3
+    "@storybook/addons": 6.4.14
+    "@storybook/core-client": 6.4.14
+    "@storybook/core-common": 6.4.14
+    "@storybook/node-logger": 6.4.14
+    "@storybook/theming": 6.4.14
+    "@storybook/ui": 6.4.14
     "@types/node": ^14.0.10
     "@types/webpack": ^4.41.26
     babel-loader: ^8.0.0
@@ -3280,46 +4101,118 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 3c57bc84c71d46f9060a39f10988c1b19745c52e2222e0224d1adda51ce93369567fc127f79657a01b0e22dfc22224ffeb4e5b02fdb702e253df96e1a9d46c86
+  checksum: f95bce2d4c85a2aeb7da4309c5b2b44d2076bb0fdbe7d168947df66bcaf983b93be8f6832c25e66f808cd2734f2a3333c6a03c2f84b6ee0845e7b585868e8c7f
   languageName: node
   linkType: hard
 
-"@storybook/node-logger@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/node-logger@npm:6.4.3"
+"@storybook/manager-webpack4@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/manager-webpack4@npm:6.4.19"
+  dependencies:
+    "@babel/core": ^7.12.10
+    "@babel/plugin-transform-template-literals": ^7.12.1
+    "@babel/preset-react": ^7.12.10
+    "@storybook/addons": 6.4.19
+    "@storybook/core-client": 6.4.19
+    "@storybook/core-common": 6.4.19
+    "@storybook/node-logger": 6.4.19
+    "@storybook/theming": 6.4.19
+    "@storybook/ui": 6.4.19
+    "@types/node": ^14.0.10
+    "@types/webpack": ^4.41.26
+    babel-loader: ^8.0.0
+    case-sensitive-paths-webpack-plugin: ^2.3.0
+    chalk: ^4.1.0
+    core-js: ^3.8.2
+    css-loader: ^3.6.0
+    express: ^4.17.1
+    file-loader: ^6.2.0
+    file-system-cache: ^1.0.5
+    find-up: ^5.0.0
+    fs-extra: ^9.0.1
+    html-webpack-plugin: ^4.0.0
+    node-fetch: ^2.6.1
+    pnp-webpack-plugin: 1.6.4
+    read-pkg-up: ^7.0.1
+    regenerator-runtime: ^0.13.7
+    resolve-from: ^5.0.0
+    style-loader: ^1.3.0
+    telejson: ^5.3.2
+    terser-webpack-plugin: ^4.2.3
+    ts-dedent: ^2.0.0
+    url-loader: ^4.1.1
+    util-deprecate: ^1.0.2
+    webpack: 4
+    webpack-dev-middleware: ^3.7.3
+    webpack-virtual-modules: ^0.2.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: c8ddf21cdeb67a3db743694c800b162a33186b9105bd64920a2653a418426d6d9e2bdf6b0572883e77785be9c674734023b594e4b31fbb91e0fd5e780fdabadf
+  languageName: node
+  linkType: hard
+
+"@storybook/node-logger@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/node-logger@npm:6.4.14"
   dependencies:
     "@types/npmlog": ^4.1.2
     chalk: ^4.1.0
     core-js: ^3.8.2
     npmlog: ^5.0.1
     pretty-hrtime: ^1.0.3
-  checksum: 53a621fa75307434eb3794f1cb961e9aaf85be317d6ab6514fad445bf1f1daab0b46923fedd0bf0029c99ab8d07f5d4ab1cbd2542f996609f70cb9c1d051bcec
+  checksum: e395d63b1fb99bf2250973a6ecd4e618509767c4d7b27d53038d9bd02b09cb4726bbc6ee71d1f09834cbbeee29495eeae4096481f6e5d86ab5c54d4673969f9d
   languageName: node
   linkType: hard
 
-"@storybook/postinstall@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/postinstall@npm:6.4.3"
+"@storybook/node-logger@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/node-logger@npm:6.4.19"
+  dependencies:
+    "@types/npmlog": ^4.1.2
+    chalk: ^4.1.0
+    core-js: ^3.8.2
+    npmlog: ^5.0.1
+    pretty-hrtime: ^1.0.3
+  checksum: d0224eb28161ec714f4a439b097bc659bf27b0a5d7813238324f820ed4316f8f63d1f57ed2106b5ff3ce81a84aa0d779b01841747fa301435236cec76bb06afe
+  languageName: node
+  linkType: hard
+
+"@storybook/postinstall@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/postinstall@npm:6.4.14"
   dependencies:
     core-js: ^3.8.2
-  checksum: 3d0f8f88438819e26e410595e89dc690850adaccd9c01015cfc13434a1a8d279bea114d9401c177b0528db2902177c8ce423ae6c35cb7147ad32490538710f01
+  checksum: 0b216b599c19b85e0765c2a5c789bd3c9a945b1edfef9736539688a61e750e26a8e4d1d139a0b70cca27f508691e6d2bfa9b4d4c264b5192a3f3b1876d0d7db1
   languageName: node
   linkType: hard
 
-"@storybook/preview-web@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/preview-web@npm:6.4.3"
+"@storybook/postinstall@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/postinstall@npm:6.4.19"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/channel-postmessage": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/core-events": 6.4.3
+    core-js: ^3.8.2
+  checksum: 3f2c7205f7e19ff73a53c48ba1228ef47fa9a6e36d19ae6ee9e919f3f352670016549ab00512b114d81eb6224385529dd8f169497e8ae8c2b53d51d6fb56efa4
+  languageName: node
+  linkType: hard
+
+"@storybook/preview-web@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/preview-web@npm:6.4.14"
+  dependencies:
+    "@storybook/addons": 6.4.14
+    "@storybook/channel-postmessage": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/core-events": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/store": 6.4.3
+    "@storybook/store": 6.4.14
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     qs: ^6.10.0
     regenerator-runtime: ^0.13.7
     synchronous-promise: ^2.0.15
@@ -3329,7 +4222,34 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: f277f54520c297494baa620bc29bb2c28dbb988e7393014e31f3a607586920666d8347b9fdee334175ba1d758b97ab9f0be0f719c9c3f222b11a9f19a2bd34dd
+  checksum: 55fb0b7adcc93cd87d9bc7794353874f5d28e75828eaba5de5ec45b7ef1d64a708ec2f6eeecc468d019d08eac50491cd58be620ef99444b197c5fa04934177ad
+  languageName: node
+  linkType: hard
+
+"@storybook/preview-web@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/preview-web@npm:6.4.19"
+  dependencies:
+    "@storybook/addons": 6.4.19
+    "@storybook/channel-postmessage": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/core-events": 6.4.19
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/store": 6.4.19
+    ansi-to-html: ^0.6.11
+    core-js: ^3.8.2
+    global: ^4.4.0
+    lodash: ^4.17.21
+    qs: ^6.10.0
+    regenerator-runtime: ^0.13.7
+    synchronous-promise: ^2.0.15
+    ts-dedent: ^2.0.0
+    unfetch: ^4.2.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 62dba93754f3541b72352e8322e4998b2ac2c2b97f04300fdf181120796f165701fe8299717820173bbd0fa70ca5ee19c2b9afe61cbf8a322f85708e2277d3a5
   languageName: node
   linkType: hard
 
@@ -3352,30 +4272,29 @@ __metadata:
   linkType: hard
 
 "@storybook/react@npm:^6.4.0":
-  version: 6.4.3
-  resolution: "@storybook/react@npm:6.4.3"
+  version: 6.4.19
+  resolution: "@storybook/react@npm:6.4.19"
   dependencies:
     "@babel/preset-flow": ^7.12.1
     "@babel/preset-react": ^7.12.10
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.1
-    "@storybook/addons": 6.4.3
-    "@storybook/core": 6.4.3
-    "@storybook/core-common": 6.4.3
+    "@storybook/addons": 6.4.19
+    "@storybook/core": 6.4.19
+    "@storybook/core-common": 6.4.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/node-logger": 6.4.3
+    "@storybook/node-logger": 6.4.19
     "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.253f8c1.0
     "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.3
+    "@storybook/store": 6.4.19
     "@types/webpack-env": ^1.16.0
     babel-plugin-add-react-displayname: ^0.0.5
     babel-plugin-named-asset-import: ^0.3.1
     babel-plugin-react-docgen: ^4.2.1
     core-js: ^3.8.2
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     prop-types: ^15.7.2
-    react-dev-utils: ^11.0.4
-    react-refresh: ^0.10.0
+    react-refresh: ^0.11.0
     read-pkg-up: ^7.0.1
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
@@ -3393,7 +4312,52 @@ __metadata:
     build-storybook: bin/build.js
     start-storybook: bin/index.js
     storybook-server: bin/index.js
-  checksum: 05c0184d4bf98e247b9c03e2a0c05e5f4113db4789cf225fbeab2476c8f07658cb33005e9f617460e8260c88dcc72108c81556b5be23d41c2c7fbad443087a05
+  checksum: c53c8909979732e40df62ccd5d8840cb313b5bf5625c5d8cb2a6908aaaab6c05ecb7e1a99053e3a132b7ac4187b609639c1b39e62008cbc351841f4edb77871c
+  languageName: node
+  linkType: hard
+
+"@storybook/react@npm:^6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/react@npm:6.4.14"
+  dependencies:
+    "@babel/preset-flow": ^7.12.1
+    "@babel/preset-react": ^7.12.10
+    "@pmmmwh/react-refresh-webpack-plugin": ^0.5.1
+    "@storybook/addons": 6.4.14
+    "@storybook/core": 6.4.14
+    "@storybook/core-common": 6.4.14
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/node-logger": 6.4.14
+    "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.253f8c1.0
+    "@storybook/semver": ^7.3.2
+    "@storybook/store": 6.4.14
+    "@types/webpack-env": ^1.16.0
+    babel-plugin-add-react-displayname: ^0.0.5
+    babel-plugin-named-asset-import: ^0.3.1
+    babel-plugin-react-docgen: ^4.2.1
+    core-js: ^3.8.2
+    global: ^4.4.0
+    lodash: ^4.17.21
+    prop-types: ^15.7.2
+    react-refresh: ^0.11.0
+    read-pkg-up: ^7.0.1
+    regenerator-runtime: ^0.13.7
+    ts-dedent: ^2.0.0
+    webpack: 4
+  peerDependencies:
+    "@babel/core": ^7.11.5
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    typescript:
+      optional: true
+  bin:
+    build-storybook: bin/build.js
+    start-storybook: bin/index.js
+    storybook-server: bin/index.js
+  checksum: 4e213497e2d8e4cd100d5e01b7e3df10008b6c384be14f42d3942cfee566938edf6291845c31a0280f746c0dedb77b621577dab7f3382b348f981ad6934aa7b2
   languageName: node
   linkType: hard
 
@@ -3418,16 +4382,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/router@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/router@npm:6.4.3"
+"@storybook/router@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/router@npm:6.4.14"
   dependencies:
-    "@storybook/client-logger": 6.4.3
+    "@storybook/client-logger": 6.4.14
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
     history: 5.0.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     memoizerific: ^1.11.3
     qs: ^6.10.0
     react-router: ^6.0.0
@@ -3436,7 +4400,27 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 98e4a88514f7f3983e85c031f8302f04f68d92559ad63d9b0051cd5a2b65c75aba54be5a3eb5435ce0a7879c3833d319b0777501b518533e1e5502a21223a045
+  checksum: cb11471b10df216bc968a52a194da646eae901652286db45266644e9406a06b87a08e587cd4a8e3ce317bed72f2cbed24ec3f5e4a47939bd2a7dc39093bb51fd
+  languageName: node
+  linkType: hard
+
+"@storybook/router@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/router@npm:6.4.19"
+  dependencies:
+    "@storybook/client-logger": 6.4.19
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    history: 5.0.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+    ts-dedent: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 80aafb3f492113e49ead84e5ad6458df5e49c09adad72d63db4fb6218309cd11160109b0b07f9f17199717fe30313a2831b516200d206c6023368610d6868211
   languageName: node
   linkType: hard
 
@@ -3452,24 +4436,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/source-loader@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/source-loader@npm:6.4.3"
+"@storybook/source-loader@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/source-loader@npm:6.4.14"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/client-logger": 6.4.3
+    "@storybook/addons": 6.4.14
+    "@storybook/client-logger": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
     core-js: ^3.8.2
     estraverse: ^5.2.0
     global: ^4.4.0
     loader-utils: ^2.0.0
-    lodash: ^4.17.20
-    prettier: ^2.2.1
+    lodash: ^4.17.21
+    prettier: ">=2.2.1 <=2.3.0"
     regenerator-runtime: ^0.13.7
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: a250cdc3f1b1271b08744a706c98ef3b9a4aabc2d60a96b2edb425606b88dce7cd39a4ecca9ccf48ea2d4c46400597ac8d18d0b40b315b521d76d3419038ab42
+  checksum: 5c2772175860659a6ca7c5bfbe944bf3d7120161665b62e00210e273b040ea8c2c99f2ca97847e38e1ca7dd347c9ca5112aab2a6033bc7b7336ab6e39d36d5ba
+  languageName: node
+  linkType: hard
+
+"@storybook/source-loader@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/source-loader@npm:6.4.19"
+  dependencies:
+    "@storybook/addons": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    core-js: ^3.8.2
+    estraverse: ^5.2.0
+    global: ^4.4.0
+    loader-utils: ^2.0.0
+    lodash: ^4.17.21
+    prettier: ">=2.2.1 <=2.3.0"
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: b4dfcaef03b74e348be746bf6f5db0a18ef956a767dcee6cdf933ef9200fbbac0e1dbbf5b2e92c810430daee976d3d713b1403f8744e4df263e4bd3d988de620
   languageName: node
   linkType: hard
 
@@ -3494,18 +4499,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/store@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/store@npm:6.4.3"
+"@storybook/store@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/store@npm:6.4.14"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/core-events": 6.4.3
+    "@storybook/addons": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/core-events": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     memoizerific: ^1.11.3
     regenerator-runtime: ^0.13.7
     slash: ^3.0.0
@@ -3516,19 +4521,45 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 5520e44323d343cd06e549e1bb1b5e7e96775d295aa149e3bf53a561c0228ed028dc395701c73e7cffa47d08e917e96f22ca982453258848c9ec5364fd02b95f
+  checksum: 2e23d5ac73893b73b49440349b22bebafe3010d0523b12a2f2d76dae6d8639d11270fd73361e6017095a9b8c22db514f31380739d2511dfd82d83f41e9bc85fc
   languageName: node
   linkType: hard
 
-"@storybook/svelte@npm:^6.4.0":
-  version: 6.4.3
-  resolution: "@storybook/svelte@npm:6.4.3"
+"@storybook/store@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/store@npm:6.4.19"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/core": 6.4.3
-    "@storybook/core-common": 6.4.3
+    "@storybook/addons": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/core-events": 6.4.19
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/store": 6.4.3
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    regenerator-runtime: ^0.13.7
+    slash: ^3.0.0
+    stable: ^0.1.8
+    synchronous-promise: ^2.0.15
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 665f5605c2cd98e1ba001cf9106f0e14f5d3e035d79ee2a2c7f8166a579a9f6f500c40da7b3e419886b774b69d300fb900da5a652a4565639d86646624264e21
+  languageName: node
+  linkType: hard
+
+"@storybook/svelte@npm:^6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/svelte@npm:6.4.14"
+  dependencies:
+    "@storybook/addons": 6.4.14
+    "@storybook/core": 6.4.14
+    "@storybook/core-common": 6.4.14
+    "@storybook/csf": 0.0.2--canary.87bc651.0
+    "@storybook/store": 6.4.14
     core-js: ^3.8.2
     global: ^4.4.0
     react: 16.14.0
@@ -3545,7 +4576,7 @@ __metadata:
     build-storybook: bin/build.js
     start-storybook: bin/index.js
     storybook-server: bin/index.js
-  checksum: 43fab8dff62eb1dc729b7e904b9ba79d2c178bd073eea79b1fd2f29a2739ab8f5bf8c88e87c5dbc621ca1b6811b935da3c221bedd4c1adb732c46397b132cbe9
+  checksum: 59633d837abce36407daf84e4ab872302a2ecd5569fabb914c8062d88beca12ddd9c7adca599cf70ac61a3a7298c5c8c84b289f0653e22fd668b5764e8cf1838
   languageName: node
   linkType: hard
 
@@ -3572,14 +4603,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/theming@npm:6.4.3"
+"@storybook/theming@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/theming@npm:6.4.14"
   dependencies:
     "@emotion/core": ^10.1.1
     "@emotion/is-prop-valid": ^0.8.6
     "@emotion/styled": ^10.0.27
-    "@storybook/client-logger": 6.4.3
+    "@storybook/client-logger": 6.4.14
     core-js: ^3.8.2
     deep-object-diff: ^1.1.0
     emotion-theming: ^10.0.27
@@ -3591,24 +4622,47 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 3f1dd089afda19cf95d5cc9228d9b4285486d4a6e9d763c9970b37339b4e75db3628e3c527ca7c9df9417228d9456255caf17523df351cead754b838d54d58f3
+  checksum: 2e66dd41b575eb6cfed5e9982796018baaf4dbb3d8bd3e830cf5f909371995dc1755ee51d0f8d1802f395c73136cf6bb0ec6def28a2c83b47bfeb667e23e87b7
   languageName: node
   linkType: hard
 
-"@storybook/ui@npm:6.4.3":
-  version: 6.4.3
-  resolution: "@storybook/ui@npm:6.4.3"
+"@storybook/theming@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/theming@npm:6.4.19"
   dependencies:
     "@emotion/core": ^10.1.1
-    "@storybook/addons": 6.4.3
-    "@storybook/api": 6.4.3
-    "@storybook/channels": 6.4.3
-    "@storybook/client-logger": 6.4.3
-    "@storybook/components": 6.4.3
-    "@storybook/core-events": 6.4.3
-    "@storybook/router": 6.4.3
+    "@emotion/is-prop-valid": ^0.8.6
+    "@emotion/styled": ^10.0.27
+    "@storybook/client-logger": 6.4.19
+    core-js: ^3.8.2
+    deep-object-diff: ^1.1.0
+    emotion-theming: ^10.0.27
+    global: ^4.4.0
+    memoizerific: ^1.11.3
+    polished: ^4.0.5
+    resolve-from: ^5.0.0
+    ts-dedent: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: 59e980a602bfff4f7643c9f43fdd09d75b6c08cf8eed59da45f2d9b8a8fc3233057eda953c2de98e5440d29196d0abc7f3d7838f98d66f41b57579e7b2cef5e5
+  languageName: node
+  linkType: hard
+
+"@storybook/ui@npm:6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/ui@npm:6.4.14"
+  dependencies:
+    "@emotion/core": ^10.1.1
+    "@storybook/addons": 6.4.14
+    "@storybook/api": 6.4.14
+    "@storybook/channels": 6.4.14
+    "@storybook/client-logger": 6.4.14
+    "@storybook/components": 6.4.14
+    "@storybook/core-events": 6.4.14
+    "@storybook/router": 6.4.14
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.4.3
+    "@storybook/theming": 6.4.14
     copy-to-clipboard: ^3.3.1
     core-js: ^3.8.2
     core-js-pure: ^3.8.2
@@ -3616,7 +4670,7 @@ __metadata:
     emotion-theming: ^10.0.27
     fuse.js: ^3.6.1
     global: ^4.4.0
-    lodash: ^4.17.20
+    lodash: ^4.17.21
     markdown-to-jsx: ^7.1.3
     memoizerific: ^1.11.3
     polished: ^4.0.5
@@ -3630,19 +4684,58 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 77fe36fc97584a71f1049da0c6ab4a0e927d1e6c6a841385c6a9d7f97d20ed9d2bd49d9ffdf85b7c7f7cd65d458fbd9aad648dc36a40f6537f2289793e102a7e
+  checksum: 037f284ca8cd8fd917cea02ad2e52d747b8c276c837d9dcdcf52960d23c9c42d36c5913ccc8642c5edb9ace6ac6d46640d405a046444c38c40ca8edbc77893d5
   languageName: node
   linkType: hard
 
-"@storybook/vue3@npm:^6.4.0":
-  version: 6.4.3
-  resolution: "@storybook/vue3@npm:6.4.3"
+"@storybook/ui@npm:6.4.19":
+  version: 6.4.19
+  resolution: "@storybook/ui@npm:6.4.19"
   dependencies:
-    "@storybook/addons": 6.4.3
-    "@storybook/core": 6.4.3
-    "@storybook/core-common": 6.4.3
+    "@emotion/core": ^10.1.1
+    "@storybook/addons": 6.4.19
+    "@storybook/api": 6.4.19
+    "@storybook/channels": 6.4.19
+    "@storybook/client-logger": 6.4.19
+    "@storybook/components": 6.4.19
+    "@storybook/core-events": 6.4.19
+    "@storybook/router": 6.4.19
+    "@storybook/semver": ^7.3.2
+    "@storybook/theming": 6.4.19
+    copy-to-clipboard: ^3.3.1
+    core-js: ^3.8.2
+    core-js-pure: ^3.8.2
+    downshift: ^6.0.15
+    emotion-theming: ^10.0.27
+    fuse.js: ^3.6.1
+    global: ^4.4.0
+    lodash: ^4.17.21
+    markdown-to-jsx: ^7.1.3
+    memoizerific: ^1.11.3
+    polished: ^4.0.5
+    qs: ^6.10.0
+    react-draggable: ^4.4.3
+    react-helmet-async: ^1.0.7
+    react-sizeme: ^3.0.1
+    regenerator-runtime: ^0.13.7
+    resolve-from: ^5.0.0
+    store2: ^2.12.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: bc3f19cc7b485e758c287d8e8f56f2fc96799975dce231cfa4f0d83421fb16a5632314d0ac0b6a7258201fb12878661befaf53fabb32ddcb6a4dfc91180ec3ab
+  languageName: node
+  linkType: hard
+
+"@storybook/vue3@npm:^6.4.14":
+  version: 6.4.14
+  resolution: "@storybook/vue3@npm:6.4.14"
+  dependencies:
+    "@storybook/addons": 6.4.14
+    "@storybook/core": 6.4.14
+    "@storybook/core-common": 6.4.14
     "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/store": 6.4.3
+    "@storybook/store": 6.4.14
     "@types/webpack-env": ^1.16.0
     core-js: ^3.8.2
     global: ^4.4.0
@@ -3665,7 +4758,7 @@ __metadata:
     build-storybook: bin/build.js
     start-storybook: bin/index.js
     storybook-server: bin/index.js
-  checksum: 6c3901201d1f71e399b26aedde18b2b8b4bd191989882e5cefd74a4408039b2cafb1167c4068e0bf220ea1bc6a88ec3a5b9d60bd1bda68b10694affc65e1df14
+  checksum: 2846aef37b10cd8974215c92d2631b0c46a679697b851d6d70da0aa1ecf7182a28c79e9abbabc52d018bfc4d931bacc200d2932b085a24880f977ebc8c8c7ed9
   languageName: node
   linkType: hard
 
@@ -4606,7 +5699,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"address@npm:1.1.2, address@npm:^1.0.1":
+"address@npm:^1.0.1":
   version: 1.1.2
   resolution: "address@npm:1.1.2"
   checksum: d966deee6ab9a0f96ed1d25dc73e91a248f64479c91f9daeb15237b8e3c39a02faac4e6afe8987ef9e5aea60a1593cef5882b7456ab2e6196fc0229a93ec39c2
@@ -5564,20 +6657,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:4.14.2":
-  version: 4.14.2
-  resolution: "browserslist@npm:4.14.2"
-  dependencies:
-    caniuse-lite: ^1.0.30001125
-    electron-to-chromium: ^1.3.564
-    escalade: ^3.0.2
-    node-releases: ^1.1.61
-  bin:
-    browserslist: cli.js
-  checksum: 44b5d7a444b867e1f027923f37a8ed537b4403f8a85a35869904e7d3e4071b37459df08d41ab4d425f5191f3125f1c5a191cbff9070f81f4d311803dc0a2fb0f
-  languageName: node
-  linkType: hard
-
 "browserslist@npm:^4.12.0, browserslist@npm:^4.16.6":
   version: 4.16.6
   resolution: "browserslist@npm:4.16.6"
@@ -5790,7 +6869,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001125, caniuse-lite@npm:^1.0.30001219":
+"caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001219":
   version: 1.0.30001236
   resolution: "caniuse-lite@npm:1.0.30001236"
   checksum: e1f38df1d37d3f628d84f38487e7edad2c8c57b9ea934e06455a2c3e4d8f283fa3e5b420a61f29539e38abd64942ea201de76195659c0aabfa34a3775ac21cc2
@@ -5820,7 +6899,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:2.4.2, chalk@npm:^2.0.0, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
+"chalk@npm:^2.0.0, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -5993,17 +7072,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-table3@npm:0.6.0":
-  version: 0.6.0
-  resolution: "cli-table3@npm:0.6.0"
+"cli-table3@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "cli-table3@npm:0.6.1"
   dependencies:
-    colors: ^1.1.2
-    object-assign: ^4.1.0
+    colors: 1.4.0
     string-width: ^4.2.0
   dependenciesMeta:
     colors:
       optional: true
-  checksum: 98682a2d3eef5ad07d34a08f90398d0640004e28ecf8eb59006436f11ed7b4d453db09f46c2ea880618fbd61fee66321b3b3ee1b20276bc708b6baf6f9663d75
+  checksum: 956e175f8eb019c26465b9f1e51121c08d8978e2aab04be7f8520ea8a4e67906fcbd8516dfb77e386ae3730ef0281aa21a65613dffbfa3d62969263252bd25a9
   languageName: node
   linkType: hard
 
@@ -6119,7 +7197,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colors@npm:^1.1.2":
+"colors@npm:1.4.0, colors@npm:^1.1.2":
   version: 1.4.0
   resolution: "colors@npm:1.4.0"
   checksum: 98aa2c2418ad87dedf25d781be69dc5fc5908e279d9d30c34d8b702e586a0474605b3a189511482b9d5ed0d20c867515d22749537f7bc546256c6014f3ebdcec
@@ -6486,17 +7564,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2":
-  version: 7.0.3
-  resolution: "cross-spawn@npm:7.0.3"
-  dependencies:
-    path-key: ^3.1.0
-    shebang-command: ^2.0.0
-    which: ^2.0.1
-  checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^6.0.0":
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
@@ -6507,6 +7574,17 @@ __metadata:
     shebang-command: ^1.2.0
     which: ^1.2.9
   checksum: f893bb0d96cd3d5751d04e67145bdddf25f99449531a72e82dcbbd42796bbc8268c1076c6b3ea51d4d455839902804b94bc45dfb37ecbb32ea8e54a6741c3ab9
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2":
+  version: 7.0.3
+  resolution: "cross-spawn@npm:7.0.3"
+  dependencies:
+    path-key: ^3.1.0
+    shebang-command: ^2.0.0
+    which: ^2.0.1
+  checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
   languageName: node
   linkType: hard
 
@@ -6770,19 +7848,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-port-alt@npm:1.1.6":
-  version: 1.1.6
-  resolution: "detect-port-alt@npm:1.1.6"
-  dependencies:
-    address: ^1.0.1
-    debug: ^2.6.0
-  bin:
-    detect: ./bin/detect-port
-    detect-port: ./bin/detect-port
-  checksum: 9dc37b1fa4a9dd6d4889e1045849b8d841232b598d1ca888bf712f4035b07a17cf6d537465a0d7323250048d3a5a0540e3b7cf89457efc222f96f77e2c40d16a
-  languageName: node
-  linkType: hard
-
 "detect-port@npm:^1.3.0":
   version: 1.3.0
   resolution: "detect-port@npm:1.3.0"
@@ -6949,13 +8014,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duplexer@npm:^0.1.1":
-  version: 0.1.2
-  resolution: "duplexer@npm:0.1.2"
-  checksum: 62ba61a830c56801db28ff6305c7d289b6dc9f859054e8c982abd8ee0b0a14d2e9a8e7d086ffee12e868d43e2bbe8a964be55ddbd8c8957714c87373c7a4f9b0
-  languageName: node
-  linkType: hard
-
 "duplexify@npm:^3.4.2, duplexify@npm:^3.6.0":
   version: 3.7.1
   resolution: "duplexify@npm:3.7.1"
@@ -6975,7 +8033,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.3.564, electron-to-chromium@npm:^1.3.723":
+"electron-to-chromium@npm:^1.3.723":
   version: 1.3.752
   resolution: "electron-to-chromium@npm:1.3.752"
   checksum: 48932a06469758ee743faeea3c58a3c871f2ac912461e4e29c82453e47d2a62482ccbdf59d14eb1406fd4478c807a757affc19a7002bbed30bf4ef9cfd9230a8
@@ -7423,7 +8481,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.0.2, escalade@npm:^3.1.1":
+"escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
   checksum: a3e2a99f07acb74b3ad4989c48ca0c3140f69f923e56d0cba0526240ee470b91010f9d39001f2a4a313841d237ede70a729e92125191ba5d21e74b106800b133
@@ -7434,13 +8492,6 @@ __metadata:
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 6213ca9ae00d0ab8bccb6d8d4e0a98e76237b2410302cf7df70aaa6591d509a2a37ce8998008cbecae8fc8ffaadf3fb0229535e6a145f3ce0b211d060decbb24
-  languageName: node
-  linkType: hard
-
-"escape-string-regexp@npm:2.0.0":
-  version: 2.0.0
-  resolution: "escape-string-regexp@npm:2.0.0"
-  checksum: 9f8a2d5743677c16e85c810e3024d54f0c8dea6424fad3c79ef6666e81dd0846f7437f5e729dfcdac8981bc9e5294c39b4580814d114076b8d36318f46ae4395
   languageName: node
   linkType: hard
 
@@ -7818,10 +8869,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-react@workspace:packages/example-react"
   dependencies:
-    "@storybook/addon-a11y": ^6.4.0
-    "@storybook/addon-docs": ^6.4.0
-    "@storybook/addon-essentials": ^6.4.0
-    "@storybook/react": ^6.4.0
+    "@storybook/addon-a11y": ^6.4.14
+    "@storybook/addon-docs": ^6.4.14
+    "@storybook/addon-essentials": ^6.4.14
+    "@storybook/react": ^6.4.14
     react: 17.0.2
     react-dom: 17.0.2
     storybook-builder-vite: "workspace:*"
@@ -7833,11 +8884,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-svelte@workspace:packages/example-svelte"
   dependencies:
-    "@storybook/addon-actions": ^6.4.0
-    "@storybook/addon-essentials": ^6.4.0
-    "@storybook/addon-links": ^6.4.0
+    "@storybook/addon-actions": ^6.4.14
+    "@storybook/addon-essentials": ^6.4.14
+    "@storybook/addon-links": ^6.4.14
     "@storybook/addon-svelte-csf": ^1.1.0
-    "@storybook/svelte": ^6.4.0
+    "@storybook/svelte": ^6.4.14
     "@sveltejs/vite-plugin-svelte": ^1.0.0-next.37
     storybook-builder-vite: "workspace:*"
     svelte: ^3.46.4
@@ -7849,9 +8900,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-vue@workspace:packages/example-vue"
   dependencies:
-    "@storybook/addon-a11y": ^6.4.0
-    "@storybook/addon-essentials": ^6.4.0
-    "@storybook/vue3": ^6.4.0
+    "@storybook/addon-a11y": ^6.4.14
+    "@storybook/addon-essentials": ^6.4.14
+    "@storybook/vue3": ^6.4.14
     "@vitejs/plugin-vue": ^1.10.2
     storybook-builder-vite: "workspace:*"
     vite: 2.7.0
@@ -7863,10 +8914,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-workspaces-catalog@workspace:packages/example-workspaces/packages/catalog"
   dependencies:
-    "@storybook/addon-a11y": ^6.4.0
-    "@storybook/addon-docs": ^6.4.0
-    "@storybook/addon-essentials": ^6.4.0
-    "@storybook/react": ^6.4.0
+    "@storybook/addon-a11y": ^6.4.14
+    "@storybook/addon-docs": ^6.4.14
+    "@storybook/addon-essentials": ^6.4.14
+    "@storybook/react": ^6.4.14
     react: 17.0.2
     react-dom: 17.0.2
     storybook-builder-vite: "workspace:*"
@@ -8135,13 +9186,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"filesize@npm:6.1.0":
-  version: 6.1.0
-  resolution: "filesize@npm:6.1.0"
-  checksum: c46d644cb562fba7b7e837d5cd339394492abaa06722018b91a97d2a63b6c753ef30653de5c03bf178c631185bf55c3561c28fa9ccc4e9755f42d853c6ed4d09
-  languageName: node
-  linkType: hard
-
 "fill-range@npm:^4.0.0":
   version: 4.0.0
   resolution: "fill-range@npm:4.0.0"
@@ -8207,22 +9251,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:4.1.0, find-up@npm:^4.0.0, find-up@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "find-up@npm:4.1.0"
-  dependencies:
-    locate-path: ^5.0.0
-    path-exists: ^4.0.0
-  checksum: 4c172680e8f8c1f78839486e14a43ef82e9decd0e74145f40707cc42e7420506d5ec92d9a11c22bd2c48fb0c384ea05dd30e10dd152fefeec6f2f75282a8b844
-  languageName: node
-  linkType: hard
-
 "find-up@npm:^3.0.0":
   version: 3.0.0
   resolution: "find-up@npm:3.0.0"
   dependencies:
     locate-path: ^3.0.0
   checksum: 38eba3fe7a66e4bc7f0f5a1366dc25508b7cfc349f852640e3678d26ad9a6d7e2c43eff0a472287de4a9753ef58f066a0ea892a256fa3636ad51b3fe1e17fae9
+  languageName: node
+  linkType: hard
+
+"find-up@npm:^4.0.0, find-up@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "find-up@npm:4.1.0"
+  dependencies:
+    locate-path: ^5.0.0
+    path-exists: ^4.0.0
+  checksum: 4c172680e8f8c1f78839486e14a43ef82e9decd0e74145f40707cc42e7420506d5ec92d9a11c22bd2c48fb0c384ea05dd30e10dd152fefeec6f2f75282a8b844
   languageName: node
   linkType: hard
 
@@ -8305,7 +9349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fork-ts-checker-webpack-plugin@npm:4.1.6, fork-ts-checker-webpack-plugin@npm:^4.1.6":
+"fork-ts-checker-webpack-plugin@npm:^4.1.6":
   version: 4.1.6
   resolution: "fork-ts-checker-webpack-plugin@npm:4.1.6"
   dependencies:
@@ -8723,26 +9767,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"global-modules@npm:2.0.0":
-  version: 2.0.0
-  resolution: "global-modules@npm:2.0.0"
-  dependencies:
-    global-prefix: ^3.0.0
-  checksum: d6197f25856c878c2fb5f038899f2dca7cbb2f7b7cf8999660c0104972d5cfa5c68b5a0a77fa8206bb536c3903a4615665acb9709b4d80846e1bb47eaef65430
-  languageName: node
-  linkType: hard
-
-"global-prefix@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "global-prefix@npm:3.0.0"
-  dependencies:
-    ini: ^1.3.5
-    kind-of: ^6.0.2
-    which: ^1.3.1
-  checksum: 8a82fc1d6f22c45484a4e34656cc91bf021a03e03213b0035098d605bfc612d7141f1e14a21097e8a0413b4884afd5b260df0b6a25605ce9d722e11f1df2881d
-  languageName: node
-  linkType: hard
-
 "global@npm:^4.4.0":
   version: 4.4.0
   resolution: "global@npm:4.4.0"
@@ -8784,20 +9808,6 @@ fsevents@^1.2.7:
   dependencies:
     define-properties: ^1.1.3
   checksum: 5a5f3c7ab94708260a98106b35946b74bb57f6b2013e39668dc9e8770b80a3418103b63a2b4aa01c31af15fdf6a2940398ffc0a408573c34c2304f928895adff
-  languageName: node
-  linkType: hard
-
-"globby@npm:11.0.1":
-  version: 11.0.1
-  resolution: "globby@npm:11.0.1"
-  dependencies:
-    array-union: ^2.1.0
-    dir-glob: ^3.0.1
-    fast-glob: ^3.1.1
-    ignore: ^5.1.4
-    merge2: ^1.3.0
-    slash: ^3.0.0
-  checksum: b0b26e580666ef8caf0b0facd585c1da46eb971207ee9f8c7b690c1372d77602dd072f047f26c3ae1c293807fdf8fb6890d9291d37bc6d2602b1f07386f983e5
   languageName: node
   linkType: hard
 
@@ -8865,16 +9875,6 @@ fsevents@^1.2.7:
   version: 1.0.0
   resolution: "gud@npm:1.0.0"
   checksum: 3e2eb37cf794364077c18f036d6aa259c821c7fd188f2b7935cb00d589d82a41e0ebb1be809e1a93679417f62f1ad0513e745c3cf5329596e489aef8c5e5feae
-  languageName: node
-  linkType: hard
-
-"gzip-size@npm:5.1.1":
-  version: 5.1.1
-  resolution: "gzip-size@npm:5.1.1"
-  dependencies:
-    duplexer: ^0.1.1
-    pify: ^4.0.1
-  checksum: 6451ba2210877368f6d9ee9b4dc0d14501671472801323bf81fbd38bdeb8525f40a78be45a59d0182895d51e6b60c6314b7d02bd6ed40e7225a01e8d038aac1b
   languageName: node
   linkType: hard
 
@@ -9400,13 +10400,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"immer@npm:8.0.1":
-  version: 8.0.1
-  resolution: "immer@npm:8.0.1"
-  checksum: 63d875c04882b862481a0a692816e5982975a47a57619698bc1bb52963ad3b624911991708b2b81a7af6fdac15083d408e43932d83a6a61216e5a4503efd4095
-  languageName: node
-  linkType: hard
-
 "import-fresh@npm:^3.0.0, import-fresh@npm:^3.1.0, import-fresh@npm:^3.2.1":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
@@ -9466,13 +10459,6 @@ fsevents@^1.2.7:
   version: 2.0.3
   resolution: "inherits@npm:2.0.3"
   checksum: 78cb8d7d850d20a5e9a7f3620db31483aa00ad5f722ce03a55b110e5a723539b3716a3b463e2b96ce3fe286f33afc7c131fa2f91407528ba80cea98a7545d4c0
-  languageName: node
-  linkType: hard
-
-"ini@npm:^1.3.5":
-  version: 1.3.8
-  resolution: "ini@npm:1.3.8"
-  checksum: dfd98b0ca3a4fc1e323e38a6c8eb8936e31a97a918d3b377649ea15bdb15d481207a0dda1021efbd86b464cae29a0d33c1d7dcaf6c5672bee17fa849bc50a1b3
   languageName: node
   linkType: hard
 
@@ -9915,13 +10901,6 @@ fsevents@^1.2.7:
     call-bind: ^1.0.2
     has-symbols: ^1.0.2
   checksum: 19a831a1ba88d09bb43ab30194672e6ae1461caff27254d2c160ed63c95015155ad8784e80995e46a637d0880da8f4ed63b5c3242af1b49c0b5c4666a7a2d3d8
-  languageName: node
-  linkType: hard
-
-"is-root@npm:2.1.0":
-  version: 2.1.0
-  resolution: "is-root@npm:2.1.0"
-  checksum: 37eea0822a2a9123feb58a9d101558ba276771a6d830f87005683349a9acff15958a9ca590a44e778c6b335660b83e85c744789080d734f6081a935a4880aee2
   languageName: node
   linkType: hard
 
@@ -10965,7 +11944,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.0.4, minimatch@npm:^3.0.2, minimatch@npm:^3.0.4":
+"minimatch@npm:^3.0.2, minimatch@npm:^3.0.4":
   version: 3.0.4
   resolution: "minimatch@npm:3.0.4"
   dependencies:
@@ -11313,7 +12292,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^1.1.61, node-releases@npm:^1.1.71":
+"node-releases@npm:^1.1.71":
   version: 1.1.73
   resolution: "node-releases@npm:1.1.73"
   checksum: 44a6caec3330538a669c156fa84833725ae92b317585b106e08ab292c14da09f30cb913c10f1a7402180a51b10074832d4e045b6c3512d74c37d86b41a69e63b
@@ -11561,7 +12540,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"open@npm:^7.0.2, open@npm:^7.0.3":
+"open@npm:^7.0.3":
   version: 7.4.2
   resolution: "open@npm:7.4.2"
   dependencies:
@@ -11996,15 +12975,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"pkg-up@npm:3.1.0":
-  version: 3.1.0
-  resolution: "pkg-up@npm:3.1.0"
-  dependencies:
-    find-up: ^3.0.0
-  checksum: 5bac346b7c7c903613c057ae3ab722f320716199d753f4a7d053d38f2b5955460f3e6ab73b4762c62fd3e947f58e04f1343e92089e7bb6091c90877406fcd8c8
-  languageName: node
-  linkType: hard
-
 "pnp-webpack-plugin@npm:1.6.4":
   version: 1.6.4
   resolution: "pnp-webpack-plugin@npm:1.6.4"
@@ -12222,12 +13192,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.2.1":
-  version: 2.4.1
-  resolution: "prettier@npm:2.4.1"
+"prettier@npm:>=2.2.1 <=2.3.0":
+  version: 2.3.0
+  resolution: "prettier@npm:2.3.0"
   bin:
     prettier: bin-prettier.js
-  checksum: cc6830588b401b0d742862fe9c46bc9118204fb307c3abe0e49e95b35ed23629573807ffdf9cdd65289c252a0bb51fc0171437f6626ee36378dea80f0ee80b91
+  checksum: e8851a45f60f2994775f96e07964646c299b8a8f9c64da4fbd8efafc20db3458bdcedac79aed34e1d5477540b3aa04f6499adc4979cb7937f8ebd058a767d8ff
   languageName: node
   linkType: hard
 
@@ -12354,16 +13324,6 @@ fsevents@^1.2.7:
   dependencies:
     asap: ~2.0.3
   checksum: 475bb069130179fbd27ed2ab45f26d8862376a137a57314cf53310bdd85cc986a826fd585829be97ebc0aaf10e9d8e68be1bfe5a4a0364144b1f9eedfa940cf1
-  languageName: node
-  linkType: hard
-
-"prompts@npm:2.4.0":
-  version: 2.4.0
-  resolution: "prompts@npm:2.4.0"
-  dependencies:
-    kleur: ^3.0.3
-    sisteransi: ^1.0.5
-  checksum: 96c7bef8eb3c0bb2076d2bc5ee473f06e6d8ac01ac4d0f378dfeb0ddaf2f31c339360ec8f0f8486f78601d16ebef7c6bd9886d44b937ba01bab568b937190265
   languageName: node
   linkType: hard
 
@@ -12725,38 +13685,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-dev-utils@npm:^11.0.4":
-  version: 11.0.4
-  resolution: "react-dev-utils@npm:11.0.4"
-  dependencies:
-    "@babel/code-frame": 7.10.4
-    address: 1.1.2
-    browserslist: 4.14.2
-    chalk: 2.4.2
-    cross-spawn: 7.0.3
-    detect-port-alt: 1.1.6
-    escape-string-regexp: 2.0.0
-    filesize: 6.1.0
-    find-up: 4.1.0
-    fork-ts-checker-webpack-plugin: 4.1.6
-    global-modules: 2.0.0
-    globby: 11.0.1
-    gzip-size: 5.1.1
-    immer: 8.0.1
-    is-root: 2.1.0
-    loader-utils: 2.0.0
-    open: ^7.0.2
-    pkg-up: 3.1.0
-    prompts: 2.4.0
-    react-error-overlay: ^6.0.9
-    recursive-readdir: 2.2.2
-    shell-quote: 1.7.2
-    strip-ansi: 6.0.0
-    text-table: 0.2.0
-  checksum: b41c95010a4fb60d4ea6309423520e6268757b68df34de7e9e8dbc72549236a1f5a698ff99ad72a034ac51b042aa79ee53994330ce4df05bf867e63c5464bb3f
-  languageName: node
-  linkType: hard
-
 "react-docgen-typescript@npm:^2.0.0":
   version: 2.0.0
   resolution: "react-docgen-typescript@npm:2.0.0"
@@ -12843,13 +13771,6 @@ fsevents@^1.2.7:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
   checksum: 42bcd4423f12e9ee21b2d3f0c2a28805ff4953bd82b6be4c1f5b5f9a371115aafa36a6f3d82726d43b4912179b79e99550c2b9a772c7fe6a5cd8f7e93ff34ceb
-  languageName: node
-  linkType: hard
-
-"react-error-overlay@npm:^6.0.9":
-  version: 6.0.9
-  resolution: "react-error-overlay@npm:6.0.9"
-  checksum: 695853bc885e798008a00c10d8d94e5ac91626e8130802fea37345f9c037f41b80104345db2ee87f225feb4a4ef71b0df572b17c378a6d397b6815f6d4a84293
   languageName: node
   linkType: hard
 
@@ -12941,6 +13862,13 @@ fsevents@^1.2.7:
   version: 0.10.0
   resolution: "react-refresh@npm:0.10.0"
   checksum: 089b8ea9ad8038046c0467a2476595eedab9e30620f50daa50e844c81d626de43a44a6a628256ae58e68885d5fe1d7e05074ddfd99ece3808b013d043f0c6030
+  languageName: node
+  linkType: hard
+
+"react-refresh@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "react-refresh@npm:0.11.0"
+  checksum: 112178a05b1e0ffeaf5d9fb4e56b4410a34a73adeb04dbf13abdc50d9ac9df2ada83e81485156cca0b3fa296aa3612751b3d6cd13be4464642a43679b819cbc7
   languageName: node
   linkType: hard
 
@@ -13122,15 +14050,6 @@ fsevents@^1.2.7:
     private: ^0.1.8
     source-map: ~0.6.1
   checksum: bb6b3083153301985511ed2ae1dd244a6b8e6a1b799ce1e0db49e57162247eec98f38dc7322d13a3680e5ab85be7cdff7edc28b0be11a689f2cb5fd925d6adbb
-  languageName: node
-  linkType: hard
-
-"recursive-readdir@npm:2.2.2":
-  version: 2.2.2
-  resolution: "recursive-readdir@npm:2.2.2"
-  dependencies:
-    minimatch: 3.0.4
-  checksum: a6b22994d76458443d4a27f5fd7147ac63ad31bba972666a291d511d4d819ee40ff71ba7524c14f6a565b8cfaf7f48b318f971804b913cf538d58f04e25d1fee
   languageName: node
   linkType: hard
 
@@ -13844,13 +14763,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.7.2":
-  version: 1.7.2
-  resolution: "shell-quote@npm:1.7.2"
-  checksum: efad426fb25d8a54d06363f1f45774aa9e195f62f14fa696d542b44bfe418ab41206448b63af18d726c62e099e66d9a3f4f44858b9ea2ce4b794b41b802672d1
-  languageName: node
-  linkType: hard
-
 "side-channel@npm:^1.0.4":
   version: 1.0.4
   resolution: "side-channel@npm:1.0.4"
@@ -14379,15 +15291,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:6.0.0, strip-ansi@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "strip-ansi@npm:6.0.0"
-  dependencies:
-    ansi-regex: ^5.0.0
-  checksum: 04c3239ede44c4d195b0e66c0ad58b932f08bec7d05290416d361ff908ad282ecdaf5d9731e322c84f151d427436bde01f05b7422c3ec26dd927586736b0e5d0
-  languageName: node
-  linkType: hard
-
 "strip-ansi@npm:^3.0.0, strip-ansi@npm:^3.0.1":
   version: 3.0.1
   resolution: "strip-ansi@npm:3.0.1"
@@ -14412,6 +15315,15 @@ fsevents@^1.2.7:
   dependencies:
     ansi-regex: ^4.1.0
   checksum: bdb5f76ade97062bd88e7723aa019adbfacdcba42223b19ccb528ffb9fb0b89a5be442c663c4a3fb25268eaa3f6ea19c7c3fbae830bd1562d55adccae1fcec46
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "strip-ansi@npm:6.0.0"
+  dependencies:
+    ansi-regex: ^5.0.0
+  checksum: 04c3239ede44c4d195b0e66c0ad58b932f08bec7d05290416d361ff908ad282ecdaf5d9731e322c84f151d427436bde01f05b7422c3ec26dd927586736b0e5d0
   languageName: node
   linkType: hard
 
@@ -14674,7 +15586,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"text-table@npm:0.2.0, text-table@npm:^0.2.0":
+"text-table@npm:^0.2.0":
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
   checksum: b6937a38c80c7f84d9c11dd75e49d5c44f71d95e810a3250bd1f1797fc7117c57698204adf676b71497acc205d769d65c16ae8fa10afad832ae1322630aef10a
@@ -15731,7 +16643,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"which@npm:^1.2.9, which@npm:^1.3.1":
+"which@npm:^1.2.9":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
   dependencies:


### PR DESCRIPTION
Fixes #201 

This enables the omission of `title` properties in the default export of stories (the new storybook "autotitle" feature).  It's a little less powerful without https://github.com/eirslett/storybook-builder-vite/pull/182, but it's still nice to support this, I think.

I did notice an issue with HMR, but it seems not to be introduced in this PR, but exists in the react example on main as well.  Changing a css value _does_ still HMR, so I think there is no regression here.