### PR TITLE
Default Cache Directory Conflict Resolution

### DIFF
--- a/packages/storybook-builder-vite/build.ts
+++ b/packages/storybook-builder-vite/build.ts
@@ -12,6 +12,7 @@ export async function build(options: ExtendedOptions) {
   const config = {
     configFile: false,
     root: path.resolve(options.configDir, '..'),
+    cacheDir: ".vite-storybook",
     build: {
       outDir: options.outputDir,
       emptyOutDir: false, // do not clean before running Vite build - Storybook has already added assets in there!


### PR DESCRIPTION
There is a problem starting Vite app and Storybook under storybook-builder-vite because they share the same cache directory 
 `node_modules/.vite/`  unless explicitly reassigning. 
 This PR retargets storybook-builder-vite's cache directory into a different one to not affect the app it's running along with.