### PR TITLE
Specify vite cache directory in dev mode as well

### DIFF
--- a/packages/storybook-builder-vite/build.ts
+++ b/packages/storybook-builder-vite/build.ts
@@ -1,32 +1,21 @@
-import * as path from 'path';
 import { build as viteBuild } from 'vite';
-import { allowedEnvPrefix as envPrefix, stringifyProcessEnvs } from './envs';
-import { pluginConfig } from './vite-config';
+import { stringifyProcessEnvs } from './envs';
+import { commonConfig } from './vite-config';
 
-import type { UserConfig } from 'vite';
 import type { EnvsRaw, ExtendedOptions } from './types';
 
 export async function build(options: ExtendedOptions) {
   const { presets } = options;
 
+  const baseConfig = await commonConfig(options, 'development');
   const config = {
-    configFile: false,
-    root: path.resolve(options.configDir, '..'),
-    cacheDir: "node_modules/.vite-storybook",
+    ...baseConfig,
     build: {
       outDir: options.outputDir,
       emptyOutDir: false, // do not clean before running Vite build - Storybook has already added assets in there!
       sourcemap: true,
     },
-    envPrefix,
-    define: {},
-    resolve: {
-      alias: {
-        vue: 'vue/dist/vue.esm-bundler.js',
-      },
-    },
-    plugins: await pluginConfig(options, 'build'),
-  } as UserConfig;
+  };
 
   const finalConfig = await presets.apply('viteFinal', config, options);
 

--- a/packages/storybook-builder-vite/vite-config.ts
+++ b/packages/storybook-builder-vite/vite-config.ts
@@ -1,4 +1,6 @@
+import * as path from 'path';
 import { Plugin } from 'vite';
+import { allowedEnvPrefix as envPrefix } from './envs';
 import { TypescriptConfig } from '@storybook/core-common';
 import { mockCoreJs } from './mock-core-js';
 import { codeGeneratorPlugin } from './code-generator-plugin';
@@ -6,9 +8,30 @@ import { injectExportOrderPlugin } from './inject-export-order-plugin';
 import { mdxPlugin } from './mdx-plugin';
 import { sourceLoaderPlugin } from './source-loader-plugin';
 
+import type { UserConfig } from 'vite';
 import type { ExtendedOptions } from './types';
 
 export type PluginConfigType = 'build' | 'development';
+
+// Vite config that is common to development and production mode
+export async function commonConfig(
+  options: ExtendedOptions,
+  _type: PluginConfigType
+): Promise<UserConfig & { configFile: false; root: string }> {
+  return {
+    configFile: false,
+    root: path.resolve(options.configDir, '..'),
+    cacheDir: 'node_modules/.vite-storybook',
+    envPrefix,
+    define: {},
+    resolve: {
+      alias: {
+        vue: 'vue/dist/vue.esm-bundler.js',
+      },
+    },
+    plugins: await pluginConfig(options, _type),
+  };
+}
 
 export async function pluginConfig(options: ExtendedOptions, _type: PluginConfigType) {
   const { framework, presets } = options;

--- a/packages/storybook-builder-vite/vite-server.ts
+++ b/packages/storybook-builder-vite/vite-server.ts
@@ -15,6 +15,7 @@ export async function createViteServer(options: ExtendedOptions, devServer: Serv
   const defaultConfig = {
     configFile: false,
     root,
+    cacheDir: "node_modules/.vite-storybook",
     server: {
       middlewareMode: true,
       hmr: {

--- a/packages/storybook-builder-vite/vite-server.ts
+++ b/packages/storybook-builder-vite/vite-server.ts
@@ -1,21 +1,17 @@
-import * as path from 'path';
 import { createServer } from 'vite';
-import { allowedEnvPrefix as envPrefix, stringifyProcessEnvs } from './envs';
+import { stringifyProcessEnvs } from './envs';
 import { getOptimizeDeps } from './optimizeDeps';
-import { pluginConfig } from './vite-config';
+import { commonConfig } from './vite-config';
 
 import type { Server } from 'http';
-import type { UserConfig } from 'vite';
 import type { EnvsRaw, ExtendedOptions } from './types';
 
 export async function createViteServer(options: ExtendedOptions, devServer: Server) {
   const { port, presets } = options;
-  const root = path.resolve(options.configDir, '..');
 
+  const baseConfig = await commonConfig(options, 'development');
   const defaultConfig = {
-    configFile: false,
-    root,
-    cacheDir: "node_modules/.vite-storybook",
+    ...baseConfig,
     server: {
       middlewareMode: true,
       hmr: {
@@ -26,16 +22,8 @@ export async function createViteServer(options: ExtendedOptions, devServer: Serv
         strict: true,
       },
     },
-    envPrefix,
-    define: {},
-    resolve: {
-      alias: {
-        vue: 'vue/dist/vue.esm-bundler.js',
-      },
-    },
-    plugins: await pluginConfig(options, 'development'),
-    optimizeDeps: await getOptimizeDeps(root, options),
-  } as UserConfig;
+    optimizeDeps: await getOptimizeDeps(baseConfig.root, options),
+  };
 
   const finalConfig = await presets.apply('viteFinal', defaultConfig, options);
 


### PR DESCRIPTION
In #223 the vite cache directory for production build was set to a custom location, in order not to conflict with a vite application in the same project. This commit also applies that configuration for the development server.