### PR TITLE
Import story loading module from vite-app virtual module

### DIFF
--- a/packages/storybook-builder-vite/code-generator-plugin.ts
+++ b/packages/storybook-builder-vite/code-generator-plugin.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { transformIframeHtml } from './transform-iframe-html';
 import { generateIframeScriptCode } from './codegen-iframe-script';
 import { generateModernIframeScriptCode } from './codegen-modern-iframe-script';
-import { generateImportFnScriptCode } from './codegen-importfn-script';
+import { generateImportFnScriptCode, generateVirtualStoryEntryCode } from './codegen-importfn-script';
 
 import type { Plugin } from 'vite';
 import type { ExtendedOptions } from './types';
@@ -60,15 +60,20 @@ export function codeGeneratorPlugin(options: ExtendedOptions): Plugin {
       }
     },
     async load(id) {
+      const storyStoreV7 = options.features?.storyStoreV7;
       if (id === virtualStoriesFile) {
-        return generateImportFnScriptCode(options);
+        if (storyStoreV7) {
+          return generateImportFnScriptCode(options);
+        } else {
+          return generateVirtualStoryEntryCode(options);
+        }
       }
 
       if (id === virtualFileId) {
-        if (options.features && options.features.storyStoreV7) {
+        if (storyStoreV7) {
           return generateModernIframeScriptCode(options, { storiesFilename: virtualStoriesFile });
         } else {
-          return generateIframeScriptCode(options);
+          return generateIframeScriptCode(options, { storiesFilename: virtualStoriesFile });
         }
       }
 

--- a/packages/storybook-builder-vite/codegen-importfn-script.ts
+++ b/packages/storybook-builder-vite/codegen-importfn-script.ts
@@ -1,9 +1,10 @@
 import * as path from 'path';
+import slash from 'slash';
 import { normalizePath } from 'vite';
 import { listStories } from './list-stories';
 
 import type { Options } from '@storybook/core-common';
-
+import type { ExtendedOptions } from './types';
 /**
  * This file is largely based on https://github.com/storybookjs/storybook/blob/d1195cbd0c61687f1720fefdb772e2f490a46584/lib/core-common/src/utils/to-importFn.ts
  */
@@ -46,4 +47,33 @@ export async function generateImportFnScriptCode(options: Options) {
 
   // We can then call toImportFn to create a function that can be used to load each story dynamically.
   return (await toImportFn(stories)).trim();
+}
+
+const absoluteFilesToImport = (files: string[], name: string) =>
+  files.map((el, i) => `import ${name ? `* as ${name}_${i} from ` : ''}'/@fs/${normalizePath(el)}'`).join('\n');
+
+export async function generateVirtualStoryEntryCode(options: ExtendedOptions) {
+  const storyEntries = await listStories(options);
+  const resolveMap = storyEntries.reduce<Record<string, string>>(
+    (prev, entry) => ({ ...prev, [entry]: entry.replace(slash(process.cwd()), '.') }),
+    {}
+  );
+  const modules = storyEntries.map((entry, i) => `${JSON.stringify(entry)}: story_${i}`).join(',');
+
+  return `
+    ${absoluteFilesToImport(storyEntries, 'story')}
+
+    function loadable(key) {
+      return {${modules}}[key];
+    }
+    
+    Object.assign(loadable, {
+      keys: () => (${JSON.stringify(Object.keys(resolveMap))}),
+      resolve: (key) => (${JSON.stringify(resolveMap)}[key])
+    });
+
+    export function configStories(configure) {
+      configure(loadable, { hot: import.meta.hot }, false);
+    }
+  `.trim();
 }

--- a/packages/storybook-builder-vite/codegen-modern-iframe-script.ts
+++ b/packages/storybook-builder-vite/codegen-modern-iframe-script.ts
@@ -3,7 +3,7 @@ import { normalizePath } from 'vite';
 
 import type { ExtendedOptions } from './types';
 
-export interface GenerateModernIframeScriptCodeOptions {
+interface GenerateModernIframeScriptCodeOptions {
   storiesFilename: string;
 }
 

--- a/packages/storybook-builder-vite/input/iframe.html
+++ b/packages/storybook-builder-vite/input/iframe.html
@@ -32,6 +32,5 @@
     <div id="docs-root"></div>
 
     <script type="module" src="/virtual:/@storybook/builder-vite/vite-app.js"></script>
-    <script type="module" src="/virtual:/@storybook/builder-vite/storybook-stories.js"></script>
   </body>
 </html>


### PR DESCRIPTION
I'm working on enabling Chromatic [Turbosnap](https://www.chromatic.com/docs/turbosnap) capability for vite storybook projects, and it requires a small change to the way we load in our stories to match up more closely to how the webpack builders work.  They have a separate entrypoint for just the stories, so I've moved what used to be done in the virtual `storybook-stories.js` imported directly off of the iframe, into a virtual file that's imported from the virtual `vite-app` module.  This actually more closely aligns with the way that the "modern" (storyStoreV7) code works too, which is a nice side-benefit.  

I'm going to use `patch-package` to run this code in my own storybook at work and to ensure that turbosnap works the way I am intending.  But, I wanted to put up this PR for visibility and to get any thoughts that you might have on it, @joshwooding and @eirslett.  After I prove it out for a while, I'll mark it as ready for review.