### PR TITLE
fragile fix for: Singleton client API not yet initialized

### DIFF
--- a/packages/example-react-ts/package.json
+++ b/packages/example-react-ts/package.json
@@ -11,14 +11,14 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react": "^16.4.14",
+    "react-dom": "^16.4.14"
   },
   "devDependencies": {
-    "@storybook/addon-a11y": "^6.4.0",
-    "@storybook/addon-docs": "^6.4.0",
-    "@storybook/addon-essentials": "^6.4.0",
-    "@storybook/react": "^6.4.0",
+    "@storybook/addon-a11y": "6.4.14",
+    "@storybook/addon-docs": "6.4.14",
+    "@storybook/addon-essentials": "6.4.14",
+    "@storybook/react": "6.4.14",
     "storybook-builder-vite": "workspace:*",
     "typescript": "^4.5.4",
     "vite": "2.7.0"

--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -11,8 +11,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react": "^16.4.14",
+    "react-dom": "^16.4.14"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^6.4.14",

--- a/packages/example-workspaces/packages/catalog/package.json
+++ b/packages/example-workspaces/packages/catalog/package.json
@@ -11,8 +11,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react": "^16.4.14",
+    "react-dom": "^16.4.14"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^6.4.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,39 +2220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-a11y@npm:^6.4.0":
-  version: 6.4.19
-  resolution: "@storybook/addon-a11y@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/channels": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/components": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.19
-    axe-core: ^4.2.0
-    core-js: ^3.8.2
-    global: ^4.4.0
-    lodash: ^4.17.21
-    react-sizeme: ^3.0.1
-    regenerator-runtime: ^0.13.7
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: a7e6f544773cd6e515c88d4051ead0cae482d1df4960e8a28d4c45170814a55e56ee5433889dfc87df1d70cf587fe881fb39d042c411fa12a6c09bea21ceb2ef
-  languageName: node
-  linkType: hard
-
-"@storybook/addon-a11y@npm:^6.4.14":
+"@storybook/addon-a11y@npm:6.4.14, @storybook/addon-a11y@npm:^6.4.14":
   version: 6.4.14
   resolution: "@storybook/addon-a11y@npm:6.4.14"
   dependencies:
@@ -2318,40 +2286,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-actions@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/addon-actions@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/components": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.19
-    core-js: ^3.8.2
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    lodash: ^4.17.21
-    polished: ^4.0.5
-    prop-types: ^15.7.2
-    react-inspector: ^5.1.0
-    regenerator-runtime: ^0.13.7
-    telejson: ^5.3.2
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-    uuid-browser: ^3.1.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: ff09bfdd773c551fdfbc055e740aba0c4f75d8ca3e04e3bcff85f3d2afb792634a87901f16af7d64720c328b6cfcf76a65eea40301e40b461df26a80b45913ff
-  languageName: node
-  linkType: hard
-
 "@storybook/addon-backgrounds@npm:6.4.14":
   version: 6.4.14
   resolution: "@storybook/addon-backgrounds@npm:6.4.14"
@@ -2381,35 +2315,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-backgrounds@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/addon-backgrounds@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/components": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.19
-    core-js: ^3.8.2
-    global: ^4.4.0
-    memoizerific: ^1.11.3
-    regenerator-runtime: ^0.13.7
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: 338d844b185ab4e9bf099d39e8e6c077e3804db1eea5651c73717ece1320926e89eec178075437bf2385e255e2e47af7872671cc2fd0bbcd8e212f6169a5f91d
-  languageName: node
-  linkType: hard
-
 "@storybook/addon-controls@npm:6.4.14":
   version: 6.4.14
   resolution: "@storybook/addon-controls@npm:6.4.14"
@@ -2435,34 +2340,6 @@ __metadata:
     react-dom:
       optional: true
   checksum: 4adb29a3be1d4184c4aad3df32d3a088309a6a69602991d496c2e0faef7a3dacb639c5d89c8e019c606554c1180fd7eaea34e2f2604713adc16f5aa44f5ef9cc
-  languageName: node
-  linkType: hard
-
-"@storybook/addon-controls@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/addon-controls@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/components": 6.4.19
-    "@storybook/core-common": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/node-logger": 6.4.19
-    "@storybook/store": 6.4.19
-    "@storybook/theming": 6.4.19
-    core-js: ^3.8.2
-    lodash: ^4.17.21
-    ts-dedent: ^2.0.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: 352c2bc79796b82c9122cfd9d9985dd53bf7b13aad6e5e899fbe0f5078c0e1a8d2ad6d37138b7599aa4e0c649987d6f295ddd20c184adda0b329157bb69587a6
   languageName: node
   linkType: hard
 
@@ -2564,149 +2441,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-docs@npm:6.4.19, @storybook/addon-docs@npm:^6.4.0":
-  version: 6.4.19
-  resolution: "@storybook/addon-docs@npm:6.4.19"
-  dependencies:
-    "@babel/core": ^7.12.10
-    "@babel/generator": ^7.12.11
-    "@babel/parser": ^7.12.11
-    "@babel/plugin-transform-react-jsx": ^7.12.12
-    "@babel/preset-env": ^7.12.11
-    "@jest/transform": ^26.6.2
-    "@mdx-js/loader": ^1.6.22
-    "@mdx-js/mdx": ^1.6.22
-    "@mdx-js/react": ^1.6.22
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/builder-webpack4": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/components": 6.4.19
-    "@storybook/core": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/csf-tools": 6.4.19
-    "@storybook/node-logger": 6.4.19
-    "@storybook/postinstall": 6.4.19
-    "@storybook/preview-web": 6.4.19
-    "@storybook/source-loader": 6.4.19
-    "@storybook/store": 6.4.19
-    "@storybook/theming": 6.4.19
-    acorn: ^7.4.1
-    acorn-jsx: ^5.3.1
-    acorn-walk: ^7.2.0
-    core-js: ^3.8.2
-    doctrine: ^3.0.0
-    escodegen: ^2.0.0
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    html-tags: ^3.1.0
-    js-string-escape: ^1.0.1
-    loader-utils: ^2.0.0
-    lodash: ^4.17.21
-    nanoid: ^3.1.23
-    p-limit: ^3.1.0
-    prettier: ">=2.2.1 <=2.3.0"
-    prop-types: ^15.7.2
-    react-element-to-jsx-string: ^14.3.4
-    regenerator-runtime: ^0.13.7
-    remark-external-links: ^8.0.0
-    remark-slug: ^6.0.0
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    "@storybook/angular": 6.4.19
-    "@storybook/html": 6.4.19
-    "@storybook/react": 6.4.19
-    "@storybook/vue": 6.4.19
-    "@storybook/vue3": 6.4.19
-    "@storybook/web-components": 6.4.19
-    lit: ^2.0.0
-    lit-html: ^1.4.1 || ^2.0.0
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-    svelte: ^3.31.2
-    sveltedoc-parser: ^4.1.0
-    vue: ^2.6.10 || ^3.0.0
-    webpack: "*"
-  peerDependenciesMeta:
-    "@storybook/angular":
-      optional: true
-    "@storybook/html":
-      optional: true
-    "@storybook/react":
-      optional: true
-    "@storybook/vue":
-      optional: true
-    "@storybook/vue3":
-      optional: true
-    "@storybook/web-components":
-      optional: true
-    lit:
-      optional: true
-    lit-html:
-      optional: true
-    react:
-      optional: true
-    react-dom:
-      optional: true
-    svelte:
-      optional: true
-    sveltedoc-parser:
-      optional: true
-    vue:
-      optional: true
-    webpack:
-      optional: true
-  checksum: c2c99f3c55915960599142887870a98c7d1119d03d61f1e187dc245bfd878bc048d6189ffbca8187517d10797d655d3c44964581436afca9cf76259d3d0b1d27
-  languageName: node
-  linkType: hard
-
-"@storybook/addon-essentials@npm:^6.4.0":
-  version: 6.4.19
-  resolution: "@storybook/addon-essentials@npm:6.4.19"
-  dependencies:
-    "@storybook/addon-actions": 6.4.19
-    "@storybook/addon-backgrounds": 6.4.19
-    "@storybook/addon-controls": 6.4.19
-    "@storybook/addon-docs": 6.4.19
-    "@storybook/addon-measure": 6.4.19
-    "@storybook/addon-outline": 6.4.19
-    "@storybook/addon-toolbars": 6.4.19
-    "@storybook/addon-viewport": 6.4.19
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/node-logger": 6.4.19
-    core-js: ^3.8.2
-    regenerator-runtime: ^0.13.7
-    ts-dedent: ^2.0.0
-  peerDependencies:
-    "@babel/core": ^7.9.6
-    "@storybook/vue": 6.4.19
-    "@storybook/web-components": 6.4.19
-    babel-loader: ^8.0.0
-    lit-html: ^1.4.1 || ^2.0.0-rc.3
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-    webpack: "*"
-  peerDependenciesMeta:
-    "@storybook/vue":
-      optional: true
-    "@storybook/web-components":
-      optional: true
-    lit-html:
-      optional: true
-    react:
-      optional: true
-    react-dom:
-      optional: true
-    webpack:
-      optional: true
-  checksum: ad5b41e82ccbc564230ace6c17c1d7f9f8056d9846f123379b0a42d70c6ed5e7fa3ff57fee7aaaa65557dad59e90573faacf5a08d9a64ac4fd10772dcba5be2b
-  languageName: node
-  linkType: hard
-
-"@storybook/addon-essentials@npm:^6.4.14":
+"@storybook/addon-essentials@npm:6.4.14, @storybook/addon-essentials@npm:^6.4.14":
   version: 6.4.14
   resolution: "@storybook/addon-essentials@npm:6.4.14"
   dependencies:
@@ -2802,30 +2537,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-measure@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/addon-measure@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/components": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    core-js: ^3.8.2
-    global: ^4.4.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: bc9ff0cdc54d085027b02a2c1894c22900db6ddbe79b6e5d01de82ae0605fe95dca6a9bb2a100853fea242c473db47f8b2eb1e8daae55157a4383a64840358f4
-  languageName: node
-  linkType: hard
-
 "@storybook/addon-outline@npm:6.4.14":
   version: 6.4.14
   resolution: "@storybook/addon-outline@npm:6.4.14"
@@ -2849,32 +2560,6 @@ __metadata:
     react-dom:
       optional: true
   checksum: ea3eb36d597e25ebf73f52f1dbacbb026bd9adb9f98796a0aede804b1eac8d580fdf705414b435fd31835c643ece23debeaae8871e39b31fb5c80d69634416c9
-  languageName: node
-  linkType: hard
-
-"@storybook/addon-outline@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/addon-outline@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/components": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    core-js: ^3.8.2
-    global: ^4.4.0
-    regenerator-runtime: ^0.13.7
-    ts-dedent: ^2.0.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: c8f6fcae9ca03717b1b767a7504c49cf9a0c5ae81d5489e960544fc1a986eeac4e183cceecbb5e6200aeec2e39b3821caf8e5ec64acda381dd6ffb1b8e41dd09
   languageName: node
   linkType: hard
 
@@ -2929,28 +2614,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-toolbars@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/addon-toolbars@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/components": 6.4.19
-    "@storybook/theming": 6.4.19
-    core-js: ^3.8.2
-    regenerator-runtime: ^0.13.7
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: 32e8e1ff57c55a5db57efc3703331dc11472abd86c8cfac28c622465ea3f76bf819c80623f10166d034cf9e1db71cdf1db4d069a4cec6124f60514a8c712d210
-  languageName: node
-  linkType: hard
-
 "@storybook/addon-viewport@npm:6.4.14":
   version: 6.4.14
   resolution: "@storybook/addon-viewport@npm:6.4.14"
@@ -2975,38 +2638,6 @@ __metadata:
     react-dom:
       optional: true
   checksum: f9c72fd0976ca98d86a1afb81f19a0ca311a6294a880bcc64f2400157c9273e19295a58c86465caaffb9c730d4feea6936c60f3db731ee1710befd5996424c46
-  languageName: node
-  linkType: hard
-
-"@storybook/addon-viewport@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/addon-viewport@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/components": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/theming": 6.4.19
-    core-js: ^3.8.2
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    memoizerific: ^1.11.3
-    prop-types: ^15.7.2
-    regenerator-runtime: ^0.13.7
-    store2: ^2.12.0
-    telejson: ^5.3.2
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: 4d99d4596ed04aba67394b138e546cbd5996a1645e41c411e3068be908028200dcfd9aa0a18e6fcbde134e3fc10b0d92d337c21da4451d67532cf6fc3739b4a4
   languageName: node
   linkType: hard
 
@@ -3049,28 +2680,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: a94de702b9d20e38ad5a1b563d85a879c4e1f870f3d760d7bc4de149ba5ec060e901ef3ac8d252bc4600fb70d20aa64664f27418f29322905e20c037e87a9da2
-  languageName: node
-  linkType: hard
-
-"@storybook/addons@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/addons@npm:6.4.19"
-  dependencies:
-    "@storybook/api": 6.4.19
-    "@storybook/channels": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/router": 6.4.19
-    "@storybook/theming": 6.4.19
-    "@types/webpack-env": ^1.16.0
-    core-js: ^3.8.2
-    global: ^4.4.0
-    regenerator-runtime: ^0.13.7
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: 867e93a83c1145443693a4af04a83b597afde2663d779cf81db53cc1f77d53da1d4255bd7b403a19685cd0df739c4863eed31f2ef2f1a5c9ca4ae025e191240a
   languageName: node
   linkType: hard
 
@@ -3130,34 +2739,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: 51e1bec50259b0e3ae9ff96f4e8d5c340e22cff25837c50bf6ff0405c1bddf48998aaa8cdaa3810b41ff0052fda2ed8c17bd28fb77cd7c568b283224baac0be9
-  languageName: node
-  linkType: hard
-
-"@storybook/api@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/api@npm:6.4.19"
-  dependencies:
-    "@storybook/channels": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/router": 6.4.19
-    "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.4.19
-    core-js: ^3.8.2
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    lodash: ^4.17.21
-    memoizerific: ^1.11.3
-    regenerator-runtime: ^0.13.7
-    store2: ^2.12.0
-    telejson: ^5.3.2
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: 305c413ee81f98c0064bbefdd88ee61f4ce0af18465412d7e771ba7af9825c4aa134d827d21f5e7e0dafbb41fafd5a68c65df29525de8bd382b24a960b78e97a
   languageName: node
   linkType: hard
 
@@ -3244,89 +2825,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/builder-webpack4@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/builder-webpack4@npm:6.4.19"
-  dependencies:
-    "@babel/core": ^7.12.10
-    "@babel/plugin-proposal-class-properties": ^7.12.1
-    "@babel/plugin-proposal-decorators": ^7.12.12
-    "@babel/plugin-proposal-export-default-from": ^7.12.1
-    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.12.1
-    "@babel/plugin-proposal-object-rest-spread": ^7.12.1
-    "@babel/plugin-proposal-optional-chaining": ^7.12.7
-    "@babel/plugin-proposal-private-methods": ^7.12.1
-    "@babel/plugin-syntax-dynamic-import": ^7.8.3
-    "@babel/plugin-transform-arrow-functions": ^7.12.1
-    "@babel/plugin-transform-block-scoping": ^7.12.12
-    "@babel/plugin-transform-classes": ^7.12.1
-    "@babel/plugin-transform-destructuring": ^7.12.1
-    "@babel/plugin-transform-for-of": ^7.12.1
-    "@babel/plugin-transform-parameters": ^7.12.1
-    "@babel/plugin-transform-shorthand-properties": ^7.12.1
-    "@babel/plugin-transform-spread": ^7.12.1
-    "@babel/plugin-transform-template-literals": ^7.12.1
-    "@babel/preset-env": ^7.12.11
-    "@babel/preset-react": ^7.12.10
-    "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/channel-postmessage": 6.4.19
-    "@storybook/channels": 6.4.19
-    "@storybook/client-api": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/components": 6.4.19
-    "@storybook/core-common": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/node-logger": 6.4.19
-    "@storybook/preview-web": 6.4.19
-    "@storybook/router": 6.4.19
-    "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.19
-    "@storybook/theming": 6.4.19
-    "@storybook/ui": 6.4.19
-    "@types/node": ^14.0.10
-    "@types/webpack": ^4.41.26
-    autoprefixer: ^9.8.6
-    babel-loader: ^8.0.0
-    babel-plugin-macros: ^2.8.0
-    babel-plugin-polyfill-corejs3: ^0.1.0
-    case-sensitive-paths-webpack-plugin: ^2.3.0
-    core-js: ^3.8.2
-    css-loader: ^3.6.0
-    file-loader: ^6.2.0
-    find-up: ^5.0.0
-    fork-ts-checker-webpack-plugin: ^4.1.6
-    glob: ^7.1.6
-    glob-promise: ^3.4.0
-    global: ^4.4.0
-    html-webpack-plugin: ^4.0.0
-    pnp-webpack-plugin: 1.6.4
-    postcss: ^7.0.36
-    postcss-flexbugs-fixes: ^4.2.1
-    postcss-loader: ^4.2.0
-    raw-loader: ^4.0.2
-    stable: ^0.1.8
-    style-loader: ^1.3.0
-    terser-webpack-plugin: ^4.2.3
-    ts-dedent: ^2.0.0
-    url-loader: ^4.1.1
-    util-deprecate: ^1.0.2
-    webpack: 4
-    webpack-dev-middleware: ^3.7.3
-    webpack-filter-warnings-plugin: ^1.2.1
-    webpack-hot-middleware: ^2.25.1
-    webpack-virtual-modules: ^0.2.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 6117b3063e589b1ca92b03cb16fb6258d97aef8828012390bcd4566e813ea8b03b042ba0f9ccf69efa0c21102a0b843dcca544784c25cc8b09103e32991160ad
-  languageName: node
-  linkType: hard
-
 "@storybook/channel-postmessage@npm:6.4.14":
   version: 6.4.14
   resolution: "@storybook/channel-postmessage@npm:6.4.14"
@@ -3342,21 +2840,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/channel-postmessage@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/channel-postmessage@npm:6.4.19"
-  dependencies:
-    "@storybook/channels": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/core-events": 6.4.19
-    core-js: ^3.8.2
-    global: ^4.4.0
-    qs: ^6.10.0
-    telejson: ^5.3.2
-  checksum: 1cb783c13209859d4f4a43e79b348aef749842e323f48f8ce49fe67f7a9aecdda7b4b1722c18ac8c186ca55fccc29fe8426e303d8f2486aeb0a4db04836c981b
-  languageName: node
-  linkType: hard
-
 "@storybook/channel-websocket@npm:6.4.14":
   version: 6.4.14
   resolution: "@storybook/channel-websocket@npm:6.4.14"
@@ -3367,19 +2850,6 @@ __metadata:
     global: ^4.4.0
     telejson: ^5.3.2
   checksum: 2a3363d7312cd9d11fc9ad7da373d9b41c14a262b9dc5f6fa23f9b0c446583c19bb662e65083dd46a9229a6497019b556e2ca8567b24f76cccb761c8cab23726
-  languageName: node
-  linkType: hard
-
-"@storybook/channel-websocket@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/channel-websocket@npm:6.4.19"
-  dependencies:
-    "@storybook/channels": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    core-js: ^3.8.2
-    global: ^4.4.0
-    telejson: ^5.3.2
-  checksum: 2a69258308c3701b35ce3a3b6a216ec8d3c7d28bc875757677f6b284fd1da75849565d92846a509cafd8ce8f75513c5495d85f44c342c67e0887c19154862867
   languageName: node
   linkType: hard
 
@@ -3402,17 +2872,6 @@ __metadata:
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
   checksum: 614aa84dca406e024a42606fd01f1290dc79042641a2feb4e74eb5e2d8ac28271093c78cc189207bae6ee6cf90c0024f1f3846c8cd6c4b360bf927e13afc0b73
-  languageName: node
-  linkType: hard
-
-"@storybook/channels@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/channels@npm:6.4.19"
-  dependencies:
-    core-js: ^3.8.2
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  checksum: 034c26467cb6dad9b893ee1655a5a550b588fa96d3306d38a775e8fb5b3b9e9da22da2111fc315c0c85a8aaf31f417242b1bd2238e1df84a56d6cef22fac9f64
   languageName: node
   linkType: hard
 
@@ -3447,37 +2906,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/client-api@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/client-api@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/channel-postmessage": 6.4.19
-    "@storybook/channels": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/store": 6.4.19
-    "@types/qs": ^6.9.5
-    "@types/webpack-env": ^1.16.0
-    core-js: ^3.8.2
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    lodash: ^4.17.21
-    memoizerific: ^1.11.3
-    qs: ^6.10.0
-    regenerator-runtime: ^0.13.7
-    store2: ^2.12.0
-    synchronous-promise: ^2.0.15
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: 1e94a98d99d4011a1b61a77ee928c90c2d7dfedb7e692c83a571158a8bae74cbe478a2d3a41623ecec69b28f34da21869dd3f25517425d5fce6117367048ebaf
-  languageName: node
-  linkType: hard
-
 "@storybook/client-logger@npm:6.3.12":
   version: 6.3.12
   resolution: "@storybook/client-logger@npm:6.3.12"
@@ -3495,16 +2923,6 @@ __metadata:
     core-js: ^3.8.2
     global: ^4.4.0
   checksum: fbe2c3161219724932b337455d48b84bd7f33da6f0aab8d8ef4c9c5f39167118185c06fd0291ce33dddb9c2b2991fb4b80b84537ef0aa3baa9c5d1e58356af76
-  languageName: node
-  linkType: hard
-
-"@storybook/client-logger@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/client-logger@npm:6.4.19"
-  dependencies:
-    core-js: ^3.8.2
-    global: ^4.4.0
-  checksum: 06eb583d05c951d526c7a7e2de461a693d2b491fc35f35a716762e031b3978d4d479c9dcdd81c855d3051318ee4fbd43fe0718b66d560b9d97e28bde1ce7378c
   languageName: node
   linkType: hard
 
@@ -3543,41 +2961,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/components@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/components@npm:6.4.19"
-  dependencies:
-    "@popperjs/core": ^2.6.0
-    "@storybook/client-logger": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/theming": 6.4.19
-    "@types/color-convert": ^2.0.0
-    "@types/overlayscrollbars": ^1.12.0
-    "@types/react-syntax-highlighter": 11.0.5
-    color-convert: ^2.0.1
-    core-js: ^3.8.2
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    lodash: ^4.17.21
-    markdown-to-jsx: ^7.1.3
-    memoizerific: ^1.11.3
-    overlayscrollbars: ^1.13.1
-    polished: ^4.0.5
-    prop-types: ^15.7.2
-    react-colorful: ^5.1.2
-    react-popper-tooltip: ^3.1.1
-    react-syntax-highlighter: ^13.5.3
-    react-textarea-autosize: ^8.3.0
-    regenerator-runtime: ^0.13.7
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: 200ea23620f191b571bbb182109716eb00405eeb7deb16e61fe38434d1c12b8ec3a2edc209ac128ead3dd46c2e03146bf84b63f5f8707b5dd0aa715624b97f52
-  languageName: node
-  linkType: hard
-
 "@storybook/core-client@npm:6.4.14":
   version: 6.4.14
   resolution: "@storybook/core-client@npm:6.4.14"
@@ -3610,41 +2993,6 @@ __metadata:
     typescript:
       optional: true
   checksum: a48a727be20e5bb0f085c41cb19503c94b37ca39a9b8501838de1e3db1cf480c35bfa88d4f53565542a159825850cc1577917e295064cde24543de09fa47209f
-  languageName: node
-  linkType: hard
-
-"@storybook/core-client@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/core-client@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/channel-postmessage": 6.4.19
-    "@storybook/channel-websocket": 6.4.19
-    "@storybook/client-api": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/preview-web": 6.4.19
-    "@storybook/store": 6.4.19
-    "@storybook/ui": 6.4.19
-    airbnb-js-shims: ^2.2.1
-    ansi-to-html: ^0.6.11
-    core-js: ^3.8.2
-    global: ^4.4.0
-    lodash: ^4.17.21
-    qs: ^6.10.0
-    regenerator-runtime: ^0.13.7
-    ts-dedent: ^2.0.0
-    unfetch: ^4.2.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-    webpack: "*"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: f288a68f09bef1a88a72dcff8c8190ee8f75f2d93dd1404e33d62cd2d8a34d937553456349f0390c9f14442d5a77eb8c547ff9127d315f2db1b339ed7a841139
   languageName: node
   linkType: hard
 
@@ -3711,69 +3059,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/core-common@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/core-common@npm:6.4.19"
-  dependencies:
-    "@babel/core": ^7.12.10
-    "@babel/plugin-proposal-class-properties": ^7.12.1
-    "@babel/plugin-proposal-decorators": ^7.12.12
-    "@babel/plugin-proposal-export-default-from": ^7.12.1
-    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.12.1
-    "@babel/plugin-proposal-object-rest-spread": ^7.12.1
-    "@babel/plugin-proposal-optional-chaining": ^7.12.7
-    "@babel/plugin-proposal-private-methods": ^7.12.1
-    "@babel/plugin-syntax-dynamic-import": ^7.8.3
-    "@babel/plugin-transform-arrow-functions": ^7.12.1
-    "@babel/plugin-transform-block-scoping": ^7.12.12
-    "@babel/plugin-transform-classes": ^7.12.1
-    "@babel/plugin-transform-destructuring": ^7.12.1
-    "@babel/plugin-transform-for-of": ^7.12.1
-    "@babel/plugin-transform-parameters": ^7.12.1
-    "@babel/plugin-transform-shorthand-properties": ^7.12.1
-    "@babel/plugin-transform-spread": ^7.12.1
-    "@babel/preset-env": ^7.12.11
-    "@babel/preset-react": ^7.12.10
-    "@babel/preset-typescript": ^7.12.7
-    "@babel/register": ^7.12.1
-    "@storybook/node-logger": 6.4.19
-    "@storybook/semver": ^7.3.2
-    "@types/node": ^14.0.10
-    "@types/pretty-hrtime": ^1.0.0
-    babel-loader: ^8.0.0
-    babel-plugin-macros: ^3.0.1
-    babel-plugin-polyfill-corejs3: ^0.1.0
-    chalk: ^4.1.0
-    core-js: ^3.8.2
-    express: ^4.17.1
-    file-system-cache: ^1.0.5
-    find-up: ^5.0.0
-    fork-ts-checker-webpack-plugin: ^6.0.4
-    fs-extra: ^9.0.1
-    glob: ^7.1.6
-    handlebars: ^4.7.7
-    interpret: ^2.2.0
-    json5: ^2.1.3
-    lazy-universal-dotenv: ^3.0.1
-    picomatch: ^2.3.0
-    pkg-dir: ^5.0.0
-    pretty-hrtime: ^1.0.3
-    resolve-from: ^5.0.0
-    slash: ^3.0.0
-    telejson: ^5.3.2
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-    webpack: 4
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 3f10064014cd6aa429f5bacc3e6fb741d47b670dc2e4c60dac20251786246f2c485abb226eca6d32c6ff382e14d1758b175c160115c34fb3b647067bb6653283
-  languageName: node
-  linkType: hard
-
 "@storybook/core-events@npm:6.3.12":
   version: 6.3.12
   resolution: "@storybook/core-events@npm:6.3.12"
@@ -3789,15 +3074,6 @@ __metadata:
   dependencies:
     core-js: ^3.8.2
   checksum: b4e050129aa53c1001caf828c4a303df155f662168e6e9971d19bf7892ab79454d24b14199c423bf1f756369f24f042513dee618b13055e2e0cb4dfb87ad13e6
-  languageName: node
-  linkType: hard
-
-"@storybook/core-events@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/core-events@npm:6.4.19"
-  dependencies:
-    core-js: ^3.8.2
-  checksum: a10620f3f6b6e0dd22951c3c2287482bdb3e53c98b4b482f142aa2e979ae993a9ee626686a7320f97ce2fe82dcb5afec037346abfda4f33c2f612b1cd83c74a2
   languageName: node
   linkType: hard
 
@@ -3863,68 +3139,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/core-server@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/core-server@npm:6.4.19"
-  dependencies:
-    "@discoveryjs/json-ext": ^0.5.3
-    "@storybook/builder-webpack4": 6.4.19
-    "@storybook/core-client": 6.4.19
-    "@storybook/core-common": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/csf-tools": 6.4.19
-    "@storybook/manager-webpack4": 6.4.19
-    "@storybook/node-logger": 6.4.19
-    "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.19
-    "@types/node": ^14.0.10
-    "@types/node-fetch": ^2.5.7
-    "@types/pretty-hrtime": ^1.0.0
-    "@types/webpack": ^4.41.26
-    better-opn: ^2.1.1
-    boxen: ^5.1.2
-    chalk: ^4.1.0
-    cli-table3: ^0.6.1
-    commander: ^6.2.1
-    compression: ^1.7.4
-    core-js: ^3.8.2
-    cpy: ^8.1.2
-    detect-port: ^1.3.0
-    express: ^4.17.1
-    file-system-cache: ^1.0.5
-    fs-extra: ^9.0.1
-    globby: ^11.0.2
-    ip: ^1.1.5
-    lodash: ^4.17.21
-    node-fetch: ^2.6.1
-    pretty-hrtime: ^1.0.3
-    prompts: ^2.4.0
-    regenerator-runtime: ^0.13.7
-    serve-favicon: ^2.5.0
-    slash: ^3.0.0
-    telejson: ^5.3.3
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-    watchpack: ^2.2.0
-    webpack: 4
-    ws: ^8.2.3
-  peerDependencies:
-    "@storybook/builder-webpack5": 6.4.19
-    "@storybook/manager-webpack5": 6.4.19
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    "@storybook/builder-webpack5":
-      optional: true
-    "@storybook/manager-webpack5":
-      optional: true
-    typescript:
-      optional: true
-  checksum: 7c601f1bbf1c837a5128abdc5e751d91c3bfb34ba80348b9dc1a434e51cca10e33fc16da7db322b6850b0e9229fb2dc3b4b02c535306cb97a9179b0bc272947f
-  languageName: node
-  linkType: hard
-
 "@storybook/core@npm:6.4.14":
   version: 6.4.14
   resolution: "@storybook/core@npm:6.4.14"
@@ -3942,26 +3156,6 @@ __metadata:
     typescript:
       optional: true
   checksum: ac19373e73529b143834f85d9bedbf93cd646fccb206591b05e400bada5631a14fd5c5566416f235d541ce1fb544441265d8c1f65e99376c3b0131357c59c642
-  languageName: node
-  linkType: hard
-
-"@storybook/core@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/core@npm:6.4.19"
-  dependencies:
-    "@storybook/core-client": 6.4.19
-    "@storybook/core-server": 6.4.19
-  peerDependencies:
-    "@storybook/builder-webpack5": 6.4.19
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-    webpack: "*"
-  peerDependenciesMeta:
-    "@storybook/builder-webpack5":
-      optional: true
-    typescript:
-      optional: true
-  checksum: 07b510c3983a816d94f12d55c5e6b20f19f7d2419429a89bb1f787a88f325733bf761be934a796fe7a90a625a544e838f7f2e48a2750e7099a318013e19f0e19
   languageName: node
   linkType: hard
 
@@ -3987,31 +3181,6 @@ __metadata:
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
   checksum: 448cb846ee609ad76b5bd35921779e73f79bdaf7ab1b45687bfe6f3b57b8ec3e52b77dc5a672f9693068f04a9058ec306d2a524e7bef9e58d82c234ce1403224
-  languageName: node
-  linkType: hard
-
-"@storybook/csf-tools@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/csf-tools@npm:6.4.19"
-  dependencies:
-    "@babel/core": ^7.12.10
-    "@babel/generator": ^7.12.11
-    "@babel/parser": ^7.12.11
-    "@babel/plugin-transform-react-jsx": ^7.12.12
-    "@babel/preset-env": ^7.12.11
-    "@babel/traverse": ^7.12.11
-    "@babel/types": ^7.12.11
-    "@mdx-js/mdx": ^1.6.22
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    core-js: ^3.8.2
-    fs-extra: ^9.0.1
-    global: ^4.4.0
-    js-string-escape: ^1.0.1
-    lodash: ^4.17.21
-    prettier: ">=2.2.1 <=2.3.0"
-    regenerator-runtime: ^0.13.7
-    ts-dedent: ^2.0.0
-  checksum: 33c01f8837fb001129aa28c5aefb6c46bd3f3780e73ec108545f2f87aef1041bfed1bde04578d68c6b759e19839e084052c5b3c532733ff762285f1e8040a37c
   languageName: node
   linkType: hard
 
@@ -4105,56 +3274,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/manager-webpack4@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/manager-webpack4@npm:6.4.19"
-  dependencies:
-    "@babel/core": ^7.12.10
-    "@babel/plugin-transform-template-literals": ^7.12.1
-    "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.4.19
-    "@storybook/core-client": 6.4.19
-    "@storybook/core-common": 6.4.19
-    "@storybook/node-logger": 6.4.19
-    "@storybook/theming": 6.4.19
-    "@storybook/ui": 6.4.19
-    "@types/node": ^14.0.10
-    "@types/webpack": ^4.41.26
-    babel-loader: ^8.0.0
-    case-sensitive-paths-webpack-plugin: ^2.3.0
-    chalk: ^4.1.0
-    core-js: ^3.8.2
-    css-loader: ^3.6.0
-    express: ^4.17.1
-    file-loader: ^6.2.0
-    file-system-cache: ^1.0.5
-    find-up: ^5.0.0
-    fs-extra: ^9.0.1
-    html-webpack-plugin: ^4.0.0
-    node-fetch: ^2.6.1
-    pnp-webpack-plugin: 1.6.4
-    read-pkg-up: ^7.0.1
-    regenerator-runtime: ^0.13.7
-    resolve-from: ^5.0.0
-    style-loader: ^1.3.0
-    telejson: ^5.3.2
-    terser-webpack-plugin: ^4.2.3
-    ts-dedent: ^2.0.0
-    url-loader: ^4.1.1
-    util-deprecate: ^1.0.2
-    webpack: 4
-    webpack-dev-middleware: ^3.7.3
-    webpack-virtual-modules: ^0.2.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: c8ddf21cdeb67a3db743694c800b162a33186b9105bd64920a2653a418426d6d9e2bdf6b0572883e77785be9c674734023b594e4b31fbb91e0fd5e780fdabadf
-  languageName: node
-  linkType: hard
-
 "@storybook/node-logger@npm:6.4.14":
   version: 6.4.14
   resolution: "@storybook/node-logger@npm:6.4.14"
@@ -4168,34 +3287,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/node-logger@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/node-logger@npm:6.4.19"
-  dependencies:
-    "@types/npmlog": ^4.1.2
-    chalk: ^4.1.0
-    core-js: ^3.8.2
-    npmlog: ^5.0.1
-    pretty-hrtime: ^1.0.3
-  checksum: d0224eb28161ec714f4a439b097bc659bf27b0a5d7813238324f820ed4316f8f63d1f57ed2106b5ff3ce81a84aa0d779b01841747fa301435236cec76bb06afe
-  languageName: node
-  linkType: hard
-
 "@storybook/postinstall@npm:6.4.14":
   version: 6.4.14
   resolution: "@storybook/postinstall@npm:6.4.14"
   dependencies:
     core-js: ^3.8.2
   checksum: 0b216b599c19b85e0765c2a5c789bd3c9a945b1edfef9736539688a61e750e26a8e4d1d139a0b70cca27f508691e6d2bfa9b4d4c264b5192a3f3b1876d0d7db1
-  languageName: node
-  linkType: hard
-
-"@storybook/postinstall@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/postinstall@npm:6.4.19"
-  dependencies:
-    core-js: ^3.8.2
-  checksum: 3f2c7205f7e19ff73a53c48ba1228ef47fa9a6e36d19ae6ee9e919f3f352670016549ab00512b114d81eb6224385529dd8f169497e8ae8c2b53d51d6fb56efa4
   languageName: node
   linkType: hard
 
@@ -4226,33 +3323,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/preview-web@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/preview-web@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/channel-postmessage": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/store": 6.4.19
-    ansi-to-html: ^0.6.11
-    core-js: ^3.8.2
-    global: ^4.4.0
-    lodash: ^4.17.21
-    qs: ^6.10.0
-    regenerator-runtime: ^0.13.7
-    synchronous-promise: ^2.0.15
-    ts-dedent: ^2.0.0
-    unfetch: ^4.2.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: 62dba93754f3541b72352e8322e4998b2ac2c2b97f04300fdf181120796f165701fe8299717820173bbd0fa70ca5ee19c2b9afe61cbf8a322f85708e2277d3a5
-  languageName: node
-  linkType: hard
-
 "@storybook/react-docgen-typescript-plugin@npm:1.0.2-canary.253f8c1.0":
   version: 1.0.2-canary.253f8c1.0
   resolution: "@storybook/react-docgen-typescript-plugin@npm:1.0.2-canary.253f8c1.0"
@@ -4271,52 +3341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react@npm:^6.4.0":
-  version: 6.4.19
-  resolution: "@storybook/react@npm:6.4.19"
-  dependencies:
-    "@babel/preset-flow": ^7.12.1
-    "@babel/preset-react": ^7.12.10
-    "@pmmmwh/react-refresh-webpack-plugin": ^0.5.1
-    "@storybook/addons": 6.4.19
-    "@storybook/core": 6.4.19
-    "@storybook/core-common": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    "@storybook/node-logger": 6.4.19
-    "@storybook/react-docgen-typescript-plugin": 1.0.2-canary.253f8c1.0
-    "@storybook/semver": ^7.3.2
-    "@storybook/store": 6.4.19
-    "@types/webpack-env": ^1.16.0
-    babel-plugin-add-react-displayname: ^0.0.5
-    babel-plugin-named-asset-import: ^0.3.1
-    babel-plugin-react-docgen: ^4.2.1
-    core-js: ^3.8.2
-    global: ^4.4.0
-    lodash: ^4.17.21
-    prop-types: ^15.7.2
-    react-refresh: ^0.11.0
-    read-pkg-up: ^7.0.1
-    regenerator-runtime: ^0.13.7
-    ts-dedent: ^2.0.0
-    webpack: 4
-  peerDependencies:
-    "@babel/core": ^7.11.5
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
-    typescript:
-      optional: true
-  bin:
-    build-storybook: bin/build.js
-    start-storybook: bin/index.js
-    storybook-server: bin/index.js
-  checksum: c53c8909979732e40df62ccd5d8840cb313b5bf5625c5d8cb2a6908aaaab6c05ecb7e1a99053e3a132b7ac4187b609639c1b39e62008cbc351841f4edb77871c
-  languageName: node
-  linkType: hard
-
-"@storybook/react@npm:^6.4.14":
+"@storybook/react@npm:6.4.14, @storybook/react@npm:^6.4.14":
   version: 6.4.14
   resolution: "@storybook/react@npm:6.4.14"
   dependencies:
@@ -4404,26 +3429,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/router@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/router@npm:6.4.19"
-  dependencies:
-    "@storybook/client-logger": 6.4.19
-    core-js: ^3.8.2
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    history: 5.0.0
-    lodash: ^4.17.21
-    memoizerific: ^1.11.3
-    qs: ^6.10.0
-    ts-dedent: ^2.0.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: 80aafb3f492113e49ead84e5ad6458df5e49c09adad72d63db4fb6218309cd11160109b0b07f9f17199717fe30313a2831b516200d206c6023368610d6868211
-  languageName: node
-  linkType: hard
-
 "@storybook/semver@npm:^7.3.2":
   version: 7.3.2
   resolution: "@storybook/semver@npm:7.3.2"
@@ -4454,27 +3459,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: 5c2772175860659a6ca7c5bfbe944bf3d7120161665b62e00210e273b040ea8c2c99f2ca97847e38e1ca7dd347c9ca5112aab2a6033bc7b7336ab6e39d36d5ba
-  languageName: node
-  linkType: hard
-
-"@storybook/source-loader@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/source-loader@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    core-js: ^3.8.2
-    estraverse: ^5.2.0
-    global: ^4.4.0
-    loader-utils: ^2.0.0
-    lodash: ^4.17.21
-    prettier: ">=2.2.1 <=2.3.0"
-    regenerator-runtime: ^0.13.7
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: b4dfcaef03b74e348be746bf6f5db0a18ef956a767dcee6cdf933ef9200fbbac0e1dbbf5b2e92c810430daee976d3d713b1403f8744e4df263e4bd3d988de620
   languageName: node
   linkType: hard
 
@@ -4522,32 +3506,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: 2e23d5ac73893b73b49440349b22bebafe3010d0523b12a2f2d76dae6d8639d11270fd73361e6017095a9b8c22db514f31380739d2511dfd82d83f41e9bc85fc
-  languageName: node
-  linkType: hard
-
-"@storybook/store@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/store@npm:6.4.19"
-  dependencies:
-    "@storybook/addons": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/csf": 0.0.2--canary.87bc651.0
-    core-js: ^3.8.2
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    lodash: ^4.17.21
-    memoizerific: ^1.11.3
-    regenerator-runtime: ^0.13.7
-    slash: ^3.0.0
-    stable: ^0.1.8
-    synchronous-promise: ^2.0.15
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: 665f5605c2cd98e1ba001cf9106f0e14f5d3e035d79ee2a2c7f8166a579a9f6f500c40da7b3e419886b774b69d300fb900da5a652a4565639d86646624264e21
   languageName: node
   linkType: hard
 
@@ -4626,29 +3584,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/theming@npm:6.4.19"
-  dependencies:
-    "@emotion/core": ^10.1.1
-    "@emotion/is-prop-valid": ^0.8.6
-    "@emotion/styled": ^10.0.27
-    "@storybook/client-logger": 6.4.19
-    core-js: ^3.8.2
-    deep-object-diff: ^1.1.0
-    emotion-theming: ^10.0.27
-    global: ^4.4.0
-    memoizerific: ^1.11.3
-    polished: ^4.0.5
-    resolve-from: ^5.0.0
-    ts-dedent: ^2.0.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: 59e980a602bfff4f7643c9f43fdd09d75b6c08cf8eed59da45f2d9b8a8fc3233057eda953c2de98e5440d29196d0abc7f3d7838f98d66f41b57579e7b2cef5e5
-  languageName: node
-  linkType: hard
-
 "@storybook/ui@npm:6.4.14":
   version: 6.4.14
   resolution: "@storybook/ui@npm:6.4.14"
@@ -4685,45 +3620,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: 037f284ca8cd8fd917cea02ad2e52d747b8c276c837d9dcdcf52960d23c9c42d36c5913ccc8642c5edb9ace6ac6d46640d405a046444c38c40ca8edbc77893d5
-  languageName: node
-  linkType: hard
-
-"@storybook/ui@npm:6.4.19":
-  version: 6.4.19
-  resolution: "@storybook/ui@npm:6.4.19"
-  dependencies:
-    "@emotion/core": ^10.1.1
-    "@storybook/addons": 6.4.19
-    "@storybook/api": 6.4.19
-    "@storybook/channels": 6.4.19
-    "@storybook/client-logger": 6.4.19
-    "@storybook/components": 6.4.19
-    "@storybook/core-events": 6.4.19
-    "@storybook/router": 6.4.19
-    "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.4.19
-    copy-to-clipboard: ^3.3.1
-    core-js: ^3.8.2
-    core-js-pure: ^3.8.2
-    downshift: ^6.0.15
-    emotion-theming: ^10.0.27
-    fuse.js: ^3.6.1
-    global: ^4.4.0
-    lodash: ^4.17.21
-    markdown-to-jsx: ^7.1.3
-    memoizerific: ^1.11.3
-    polished: ^4.0.5
-    qs: ^6.10.0
-    react-draggable: ^4.4.3
-    react-helmet-async: ^1.0.7
-    react-sizeme: ^3.0.1
-    regenerator-runtime: ^0.13.7
-    resolve-from: ^5.0.0
-    store2: ^2.12.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: bc3f19cc7b485e758c287d8e8f56f2fc96799975dce231cfa4f0d83421fb16a5632314d0ac0b6a7258201fb12878661befaf53fabb32ddcb6a4dfc91180ec3ab
   languageName: node
   linkType: hard
 
@@ -8853,12 +7749,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-react-ts@workspace:packages/example-react-ts"
   dependencies:
-    "@storybook/addon-a11y": ^6.4.0
-    "@storybook/addon-docs": ^6.4.0
-    "@storybook/addon-essentials": ^6.4.0
-    "@storybook/react": ^6.4.0
-    react: 17.0.2
-    react-dom: 17.0.2
+    "@storybook/addon-a11y": 6.4.14
+    "@storybook/addon-docs": 6.4.14
+    "@storybook/addon-essentials": 6.4.14
+    "@storybook/react": 6.4.14
+    react: ^16.4.14
+    react-dom: ^16.4.14
     storybook-builder-vite: "workspace:*"
     typescript: ^4.5.4
     vite: 2.7.0
@@ -8873,8 +7769,8 @@ __metadata:
     "@storybook/addon-docs": ^6.4.14
     "@storybook/addon-essentials": ^6.4.14
     "@storybook/react": ^6.4.14
-    react: 17.0.2
-    react-dom: 17.0.2
+    react: ^16.4.14
+    react-dom: ^16.4.14
     storybook-builder-vite: "workspace:*"
     vite: 2.7.0
   languageName: unknown
@@ -8918,8 +7814,8 @@ __metadata:
     "@storybook/addon-docs": ^6.4.14
     "@storybook/addon-essentials": ^6.4.14
     "@storybook/react": ^6.4.14
-    react: 17.0.2
-    react-dom: 17.0.2
+    react: ^16.4.14
+    react-dom: ^16.4.14
     storybook-builder-vite: "workspace:*"
     vite: 2.7.0
   languageName: unknown
@@ -13723,7 +12619,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-dom@npm:16.14.0":
+"react-dom@npm:16.14.0, react-dom@npm:^16.4.14":
   version: 16.14.0
   resolution: "react-dom@npm:16.14.0"
   dependencies:
@@ -13734,19 +12630,6 @@ fsevents@^1.2.7:
   peerDependencies:
     react: ^16.14.0
   checksum: 5a5c49da0f106b2655a69f96c622c347febcd10532db391c262b26aec225b235357d9da1834103457683482ab1b229af7a50f6927a6b70e53150275e31785544
-  languageName: node
-  linkType: hard
-
-"react-dom@npm:17.0.2":
-  version: 17.0.2
-  resolution: "react-dom@npm:17.0.2"
-  dependencies:
-    loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-    scheduler: ^0.20.2
-  peerDependencies:
-    react: 17.0.2
-  checksum: 1c1eaa3bca7c7228d24b70932e3d7c99e70d1d04e13bb0843bbf321582bc25d7961d6b8a6978a58a598af2af496d1cedcfb1bf65f6b0960a0a8161cb8dab743c
   languageName: node
   linkType: hard
 
@@ -13939,7 +12822,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react@npm:16.14.0":
+"react@npm:16.14.0, react@npm:^16.4.14":
   version: 16.14.0
   resolution: "react@npm:16.14.0"
   dependencies:
@@ -13947,16 +12830,6 @@ fsevents@^1.2.7:
     object-assign: ^4.1.1
     prop-types: ^15.6.2
   checksum: 8484f3ecb13414526f2a7412190575fc134da785c02695eb92bb6028c930bfe1c238d7be2a125088fec663cc7cda0a3623373c46807cf2c281f49c34b79881ac
-  languageName: node
-  linkType: hard
-
-"react@npm:17.0.2":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
-  dependencies:
-    loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
   languageName: node
   linkType: hard
 
@@ -14504,16 +13377,6 @@ fsevents@^1.2.7:
     loose-envify: ^1.1.0
     object-assign: ^4.1.1
   checksum: 73e185a59e2ff5aa3609f5b9cb97ddd376f89e1610579d29939d952411ca6eb7a24907a4ea4556569dacb931467a1a4a56d94fe809ef713aa76748642cd96a6c
-  languageName: node
-  linkType: hard
-
-"scheduler@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "scheduler@npm:0.20.2"
-  dependencies:
-    loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: c4b35cf967c8f0d3e65753252d0f260271f81a81e427241295c5a7b783abf4ea9e905f22f815ab66676f5313be0a25f47be582254db8f9241b259213e999b8fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To paraphase https://github.com/yarnpkg/berry/issues/4122

`@storybook/client-api` peer depends on react.

`@storybook/svelte@6.4.3` depends on `@storybook/client-api` and `react@16.14.0`, but your workspaces depend on `@storybook/client-api` and `react@17.0.2`.

```sh
yarn why -R @storybook/client-api
yarn why -R react
```

Thats why Yarn has to create two copies of @storybook/client-api: the first copy which uses react@16.14.0 and the other copy which uses react@17.0.2

---

I've had little succes with the proposed `packageExtensions` solution, but after some mucking around with `yarn why -R` command, I discovered that downgrading React to the same version and pinning the storybook version in example-react-ts to same version as the other packages (6.4.14)  was enough to dedupe the `@storybook/client-api` package.

Fixes #50 but its a fragile fix, when upgrading or adding dependencies the issue can resurface.