### PR TITLE
Allow sub-dependencies in base optimizeDeps.include

### DIFF
--- a/packages/storybook-builder-vite/optimizeDeps.ts
+++ b/packages/storybook-builder-vite/optimizeDeps.ts
@@ -1,109 +1,121 @@
 import * as path from 'path';
-import { normalizePath } from 'vite';
+import { normalizePath, resolveConfig, UserConfig } from 'vite';
 import { listStories } from './list-stories';
 
 import type { ExtendedOptions } from './types';
 
-export async function getOptimizeDeps(root: string, options: ExtendedOptions) {
+const INCLUDE_CANDIDATES = [
+  '@base2/pretty-print-object',
+  '@emotion/core',
+  '@emotion/is-prop-valid',
+  '@emotion/styled',
+  '@mdx-js/react',
+  '@storybook/addons',
+  '@storybook/addon-docs',
+  '@storybook/addon-docs > acorn-jsx',
+  '@storybook/channel-postmessage',
+  '@storybook/channel-websocket',
+  '@storybook/client-api',
+  '@storybook/client-logger',
+  '@storybook/core/client',
+  '@storybook/csf',
+  '@storybook/preview-web',
+  '@storybook/react',
+  '@storybook/svelte',
+  '@storybook/vue3',
+  'acorn-jsx',
+  'acorn-walk',
+  'acorn',
+  'airbnb-js-shims',
+  'ansi-to-html',
+  'axe-core',
+  'color-convert',
+  'deep-object-diff',
+  'doctrine',
+  'emotion-theming',
+  'escodegen',
+  'estraverse',
+  'fast-deep-equal',
+  'global',
+  'html-tags',
+  'isobject',
+  'loader-utils',
+  'lodash/cloneDeep',
+  'lodash/isFunction',
+  'lodash/isPlainObject',
+  'lodash/isString',
+  'lodash/mapKeys',
+  'lodash/mapValues',
+  'lodash/pick',
+  'lodash/pickBy',
+  'lodash/startCase',
+  'lodash/throttle',
+  'lodash/uniq',
+  'markdown-to-jsx',
+  'memoizerific',
+  'overlayscrollbars',
+  'polished',
+  'prettier/parser-babel',
+  'prettier/parser-flow',
+  'prettier/parser-typescript',
+  'prop-types',
+  'qs',
+  'react-dom',
+  'react-fast-compare',
+  'react-is',
+  'react-textarea-autosize',
+  'react',
+  'refractor/core',
+  'refractor/lang/bash.js',
+  'refractor/lang/css.js',
+  'refractor/lang/graphql.js',
+  'refractor/lang/js-extras.js',
+  'refractor/lang/json.js',
+  'refractor/lang/jsx.js',
+  'refractor/lang/markdown.js',
+  'refractor/lang/markup.js',
+  'refractor/lang/tsx.js',
+  'refractor/lang/typescript.js',
+  'refractor/lang/yaml.js',
+  'regenerator-runtime/runtime.js',
+  'slash',
+  'stable',
+  'store2',
+  'synchronous-promise',
+  'telejson',
+  'ts-dedent',
+  'util-deprecate',
+  'uuid-browser/v4',
+  'unfetch',
+  'vue',
+  'warning',
+];
+
+/**
+ * Helper function which allows us to `filter` with an async predicate.  Uses Promise.all for performance.
+ */
+const asyncFilter = async (arr: string[], predicate: (val: string) => Promise<boolean>) =>
+  Promise.all(arr.map(predicate)).then((results) => arr.filter((_v, index) => results[index]));
+
+export async function getOptimizeDeps(
+  config: UserConfig & { configFile: false; root: string },
+  options: ExtendedOptions
+) {
+  const { root } = config;
   const absoluteStories = await listStories(options);
   const stories = absoluteStories.map((storyPath) => normalizePath(path.relative(root, storyPath)));
+  const resolvedConfig = await resolveConfig(config, 'serve', 'development');
+
+  // This function converts ids which might include ` > ` to a real path, if it exists on disk.
+  // See https://github.com/vitejs/vite/blob/67d164392e8e9081dc3f0338c4b4b8eea6c5f7da/packages/vite/src/node/optimizer/index.ts#L182-L199
+  const resolve = resolvedConfig.createResolver({ asSrc: false });
+  const include = await asyncFilter(INCLUDE_CANDIDATES, async (id) => Boolean(await resolve(id)));
 
   return {
     // We don't need to resolve the glob since vite supports globs for entries.
     entries: stories,
     // We need Vite to precompile these dependencies, because they contain non-ESM code that would break
     // if we served it directly to the browser.
-    include: [
-      '@base2/pretty-print-object',
-      '@emotion/core',
-      '@emotion/is-prop-valid',
-      '@emotion/styled',
-      '@mdx-js/react',
-      '@storybook/addons',
-      '@storybook/addon-docs',
-      '@storybook/channel-postmessage',
-      '@storybook/channel-websocket',
-      '@storybook/client-api',
-      '@storybook/client-logger',
-      '@storybook/core/client',
-      '@storybook/csf',
-      '@storybook/preview-web',
-      '@storybook/react',
-      '@storybook/svelte',
-      '@storybook/vue3',
-      'acorn-jsx',
-      'acorn-walk',
-      'acorn',
-      'airbnb-js-shims',
-      'ansi-to-html',
-      'axe-core',
-      'color-convert',
-      'deep-object-diff',
-      'doctrine',
-      'emotion-theming',
-      'escodegen',
-      'estraverse',
-      'fast-deep-equal',
-      'global',
-      'html-tags',
-      'isobject',
-      'loader-utils',
-      'lodash/cloneDeep',
-      'lodash/isFunction',
-      'lodash/isPlainObject',
-      'lodash/isString',
-      'lodash/mapKeys',
-      'lodash/mapValues',
-      'lodash/pick',
-      'lodash/pickBy',
-      'lodash/startCase',
-      'lodash/throttle',
-      'lodash/uniq',
-      'markdown-to-jsx',
-      'memoizerific',
-      'overlayscrollbars',
-      'polished',
-      'prettier/parser-babel',
-      'prettier/parser-flow',
-      'prettier/parser-typescript',
-      'prop-types',
-      'qs',
-      'react-dom',
-      'react-fast-compare',
-      'react-is',
-      'react-textarea-autosize',
-      'react',
-      'refractor/core',
-      'refractor/lang/bash.js',
-      'refractor/lang/css.js',
-      'refractor/lang/graphql.js',
-      'refractor/lang/js-extras.js',
-      'refractor/lang/json.js',
-      'refractor/lang/jsx.js',
-      'refractor/lang/markdown.js',
-      'refractor/lang/markup.js',
-      'refractor/lang/tsx.js',
-      'refractor/lang/typescript.js',
-      'refractor/lang/yaml.js',
-      'regenerator-runtime/runtime.js',
-      'slash',
-      'stable',
-      'store2',
-      'synchronous-promise',
-      'telejson',
-      'ts-dedent',
-      'util-deprecate',
-      'uuid-browser/v4',
-      'unfetch',
-      'vue',
-      'warning',
-    ].filter((m) => {
-      try {
-        require.resolve(m);
-        return true;
-      } catch (err) {
-        return false;
-      }
-    }),
+    include,
   };
 }

--- a/packages/storybook-builder-vite/vite-config.ts
+++ b/packages/storybook-builder-vite/vite-config.ts
@@ -18,17 +18,22 @@ export async function commonConfig(
   options: ExtendedOptions,
   _type: PluginConfigType
 ): Promise<UserConfig & { configFile: false; root: string }> {
+  const { framework } = options;
+
   return {
     configFile: false,
     root: path.resolve(options.configDir, '..'),
     cacheDir: 'node_modules/.vite-storybook',
     envPrefix,
     define: {},
-    resolve: {
-      alias: {
-        vue: 'vue/dist/vue.esm-bundler.js',
-      },
-    },
+    resolve:
+      framework === 'vue3'
+        ? {
+            alias: {
+              vue: 'vue/dist/vue.esm-bundler.js',
+            },
+          }
+        : {},
     plugins: await pluginConfig(options, _type),
   };
 }

--- a/packages/storybook-builder-vite/vite-server.ts
+++ b/packages/storybook-builder-vite/vite-server.ts
@@ -22,7 +22,7 @@ export async function createViteServer(options: ExtendedOptions, devServer: Serv
         strict: true,
       },
     },
-    optimizeDeps: await getOptimizeDeps(baseConfig.root, options),
+    optimizeDeps: await getOptimizeDeps(baseConfig, options),
   };
 
   const finalConfig = await presets.apply('viteFinal', defaultConfig, options);


### PR DESCRIPTION
Fixes #232 

This tweaks the way we do our `optimizeDeps.include` slightly, allowing us to add `'@storybook/addon-docs > acorn-jsx'`.  I needed to change our `filter` function to use the resolution that vite does (see https://github.com/vitejs/vite/blob/67d164392e8e9081dc3f0338c4b4b8eea6c5f7da/packages/vite/src/node/optimizer/index.ts#L182-L199), but in the end I think this is more reliable than what we were doing before, anyway.  

With this syntax in place, we might also be able to avoid optimizing the storybook deps themselves, like `@storybook/addon-docs`, which already has an ESM export and doesn't really need to be pre-bundled at all, only its sub-dependencies do.  I haven't changed anything like that in this PR, though, since I wanted to take it one-step-at-a-time.  The only change made to the list itself is the addition of `'@storybook/addon-docs > acorn-jsx'`.

I also needed to prevent the vue alias from being added unless vue is actually being used, or else vite threw an error when I tried to resolve the config.  