### PR TITLE
Fix handling of rejected promises when attempting to close the server

### DIFF
--- a/packages/storybook-builder-vite/index.ts
+++ b/packages/storybook-builder-vite/index.ts
@@ -50,9 +50,9 @@ export const start: ViteBuilder['start'] = async ({ startTime, options, router, 
   router.use(await iframeMiddleware(options as ExtendedOptions, server));
   router.use(server.middlewares);
 
-  function bail(e?: Error) {
+  async function bail(e?: Error): Promise<void> {
     try {
-      return server.close();
+      return await server.close();
     } catch (err) {
       console.warn('unable to close vite server');
     }


### PR DESCRIPTION
Current:
```ts
function bail(e?: Error) {
  try {
    returnserver.close();
  } catch (err) {
    console.warn('unable to close vite server');
  }

  throw e;
}
```

If this call to `server.close()` throws, then it does not get caught by the `catch` here as the promise is not awaited. For this catch to handle the rejection of this promise, the `server.close()` call needs to be `await`ed