### PR TITLE
Move import of framework module after configs

### DIFF
--- a/packages/storybook-builder-vite/codegen-entries.ts
+++ b/packages/storybook-builder-vite/codegen-entries.ts
@@ -9,14 +9,17 @@ const absoluteFilesToImport = (files: string[], name: string) =>
   files.map((el, i) => `import ${name ? `* as ${name}_${i} from ` : ''}'/@fs/${normalizePath(el)}'`).join('\n');
 
 export async function generateVirtualStoryEntryCode(options: ExtendedOptions) {
+  const { frameworkPath, framework } = options;
   const storyEntries = await listStories(options);
   const resolveMap = storyEntries.reduce<Record<string, string>>(
     (prev, entry) => ({ ...prev, [entry]: entry.replace(slash(process.cwd()), '.') }),
     {}
   );
   const modules = storyEntries.map((entry, i) => `${JSON.stringify(entry)}: story_${i}`).join(',');
+  const frameworkImportPath = frameworkPath || `@storybook/${framework}`;
 
   return `
+    import { configure } from '${frameworkImportPath}';
     ${absoluteFilesToImport(storyEntries, 'story')}
 
     function loadable(key) {
@@ -28,7 +31,7 @@ export async function generateVirtualStoryEntryCode(options: ExtendedOptions) {
       resolve: (key) => (${JSON.stringify(resolveMap)}[key])
     });
 
-    export function configStories(configure) {
+    export function configStories() {
       configure(loadable, { hot: import.meta.hot }, false);
     }
   `.trim();

--- a/packages/storybook-builder-vite/codegen-iframe-script.ts
+++ b/packages/storybook-builder-vite/codegen-iframe-script.ts
@@ -11,8 +11,8 @@ export async function generateIframeScriptCode(
   options: ExtendedOptions,
   { storiesFilename, previewFilename }: GenerateIframeScriptCodeOptions
 ) {
-  const { presets, frameworkPath, framework } = options;
-  const frameworkImportPath = frameworkPath || `@storybook/${framework}`;
+  const { presets } = options;
+
   const presetEntries = await presets.apply('config', [], options);
   const configEntries = [...presetEntries].filter(Boolean);
 
@@ -25,10 +25,6 @@ export async function generateIframeScriptCode(
   /** @todo Inline variable and remove `noinspection` */
   // language=JavaScript
   const code = `
-    // Ensure that the client API is initialized by the framework before any other iframe code
-    // is loaded. That way our client-apis can assume the existence of the API+store
-    import { configure } from '${frameworkImportPath}';
-
     import {
       addDecorator,
       addParameters,
@@ -39,6 +35,7 @@ export async function generateIframeScriptCode(
     import { logger } from '@storybook/client-logger';
     ${absoluteFilesToImport(configEntries, 'config')}
     import * as preview from '${previewFilename}';
+    // This import should occur after the config imports above
     import { configStories } from '${storiesFilename}';
 
     const configs = [${importArray('config', configEntries.length).concat('preview.default').join(',')}].filter(Boolean)
@@ -90,7 +87,7 @@ export async function generateIframeScriptCode(
     }
     */
 
-    configStories(configure);
+    configStories();
     `.trim();
   return code;
 }


### PR DESCRIPTION
This should fix https://github.com/storybookjs/storybook/issues/17773.  You can check it in the vue example of this repo.  In main, the docs tab does not work, and neither does the introduction story.  But with this PR, it does.  This also aligns us more closely with the webpack builder, which imports the `configure` function in the virtual story entry, not the config entry.  I tested this change in our examples back to storybook 6.4.0.